### PR TITLE
fix: internal endpoint for getting user key params

### DIFF
--- a/src/Controller/UsersController.spec.ts
+++ b/src/Controller/UsersController.spec.ts
@@ -14,7 +14,6 @@ import { UsersControllerTest } from './test/UsersControllerTest'
 import { GetSettings } from '../Domain/UseCase/GetSettings/GetSettings'
 import { GetSetting } from '../Domain/UseCase/GetSetting/GetSetting'
 import { GetUserKeyParams } from '../Domain/UseCase/GetUserKeyParams/GetUserKeyParams'
-import { UserRepostioryStub } from '../Domain/User/test/UserRepostioryStub'
 
 describe('UsersController', () => {
   let updateUser: UpdateUser
@@ -217,19 +216,12 @@ describe('UsersController', () => {
   })
 
   it('should get user key params', async () => {
-    const userUuid = '1-2-3'
-    const user = UserTest.makeSubject({
-      uuid: userUuid,
-    })
-    const userRepository = new UserRepostioryStub([ user ])
-
     const subject = UsersControllerTest.makeSubject({
       updateUser,
-      userRepository,
     })
 
     Object.assign(request, {
-      params: { userUuid },
+      query: { email: 'test@test.com' },
     })
 
     const actual = await subject.keyParams(request)
@@ -239,5 +231,20 @@ describe('UsersController', () => {
       identifier: 'test@test.com',
       version: '004',
     })
+  })
+
+  it('should error when email parameter is not given in query when gettting user key params', async () => {
+    const subject = UsersControllerTest.makeSubject({
+      updateUser,
+    })
+
+    Object.assign(request, {
+      query: {},
+    })
+
+    const actual = await subject.keyParams(request)
+
+    expect(actual.statusCode).toEqual(400)
+    expect(actual.json).toHaveProperty('error')
   })
 })

--- a/src/Controller/UsersController.ts
+++ b/src/Controller/UsersController.ts
@@ -87,11 +87,19 @@ export class UsersController extends BaseHttpController {
     return this.json(result, 400)
   }
 
-  @httpGet('/:userUuid/params')
+  @httpGet('/params')
   async keyParams(request: Request): Promise<results.JsonResult> {
-    const result = await this.getUserKeyParams.execute({
-      userUuid: request.params.userUuid,
-    })
+    const email = 'email' in request.query ? <string> request.query.email : undefined
+
+    if(!email) {
+      return this.json({
+        error: {
+          message: 'Missing mandatory request query parameters.',
+        },
+      }, 400)
+    }
+
+    const result = await this.getUserKeyParams.execute({ email })
 
     return this.json(result.keyParams)
   }

--- a/src/Domain/UseCase/GetUserKeyParams/GetUserKeyParams.spec.ts
+++ b/src/Domain/UseCase/GetUserKeyParams/GetUserKeyParams.spec.ts
@@ -54,28 +54,4 @@ describe('GetUserKeyParams', () => {
 
     expect(keyParamsFactory.createPseudoParams).toHaveBeenCalledWith('test@test.te')
   })
-
-  it('should throw error for a non existing user when searched by uuid', async () => {
-    userRepository.findOneByUuid = jest.fn().mockReturnValue(undefined)
-
-    let error = null
-    try {
-      await createUseCase().execute({ userUuid: '1-2-3' })
-    } catch (e) {
-      error = e
-    }
-
-    expect(error).not.toBeNull()
-  })
-
-  it('should throw error for a non existing user when no search criteria given', async () => {
-    let error = null
-    try {
-      await createUseCase().execute({})
-    } catch (e) {
-      error = e
-    }
-
-    expect(error).not.toBeNull()
-  })
 })

--- a/src/Domain/UseCase/GetUserKeyParams/GetUserKeyParams.ts
+++ b/src/Domain/UseCase/GetUserKeyParams/GetUserKeyParams.ts
@@ -21,20 +21,11 @@ export class GetUserKeyParams implements UseCaseInterface {
       }
     }
 
-    let user = undefined
-    if (dto.email) {
-      user = await this.userRepository.findOneByEmail(dto.email)
-      if (user === undefined) {
-        return {
-          keyParams: this.keyParamsFactory.createPseudoParams(dto.email),
-        }
+    const user = await this.userRepository.findOneByEmail(dto.email)
+    if (!user) {
+      return {
+        keyParams: this.keyParamsFactory.createPseudoParams(dto.email),
       }
-    } else if (dto.userUuid) {
-      user = await this.userRepository.findOneByUuid(dto.userUuid)
-    }
-
-    if (user === undefined) {
-      throw new Error(`User with uuid ${dto.userUuid} not found`)
     }
 
     return {

--- a/src/Domain/UseCase/GetUserKeyParams/GetUserKeyParamsDTO.ts
+++ b/src/Domain/UseCase/GetUserKeyParams/GetUserKeyParamsDTO.ts
@@ -1,7 +1,6 @@
 import { User } from '../../User/User'
 
 export type GetUserKeyParamsDTO = {
-  email?: string
-  userUuid?: string
+  email: string
   authenticatedUser?: User
 }


### PR DESCRIPTION
@mobitar @standarius I had to change this actually to querying by email - since this method is triggered when a user uuid is not yet known.