### PR TITLE
fix: allow getting user key params with authenticated parameter

### DIFF
--- a/src/Controller/AuthController.spec.ts
+++ b/src/Controller/AuthController.spec.ts
@@ -352,6 +352,7 @@ describe('AuthController', () => {
       authenticatedUser: {
         email: 'test@test.te',
       },
+      authenticated: true,
       email: 'test@test.te',
     })
 
@@ -375,6 +376,7 @@ describe('AuthController', () => {
 
     expect(getUserKeyParams.execute).toHaveBeenCalledWith({
       email: 'test2@test.te',
+      authenticated: false,
     })
 
     expect(result.statusCode).toEqual(200)

--- a/src/Controller/AuthController.ts
+++ b/src/Controller/AuthController.ts
@@ -44,6 +44,7 @@ export class AuthController extends BaseHttpController {
     if (response.locals.session) {
       const result = await this.getUserKeyParams.execute({
         email: response.locals.user.email,
+        authenticated: true,
         authenticatedUser: response.locals.user,
       })
 
@@ -74,6 +75,7 @@ export class AuthController extends BaseHttpController {
 
     const result = await this.getUserKeyParams.execute({
       email: <string> request.query.email,
+      authenticated: false,
     })
 
     return this.json(result.keyParams)

--- a/src/Controller/UsersController.spec.ts
+++ b/src/Controller/UsersController.spec.ts
@@ -233,6 +233,24 @@ describe('UsersController', () => {
     })
   })
 
+  it('should get user key params for authenticated user', async () => {
+    const subject = UsersControllerTest.makeSubject({
+      updateUser,
+    })
+
+    Object.assign(request, {
+      query: { email: 'test@test.com', authenticated: 'true' },
+    })
+
+    const actual = await subject.keyParams(request)
+
+    expect(actual.statusCode).toEqual(200)
+    expect(actual.json).toEqual({
+      identifier: 'test@test.com',
+      version: '004',
+    })
+  })
+
   it('should error when email parameter is not given in query when gettting user key params', async () => {
     const subject = UsersControllerTest.makeSubject({
       updateUser,

--- a/src/Controller/UsersController.ts
+++ b/src/Controller/UsersController.ts
@@ -99,7 +99,10 @@ export class UsersController extends BaseHttpController {
       }, 400)
     }
 
-    const result = await this.getUserKeyParams.execute({ email })
+    const result = await this.getUserKeyParams.execute({
+      email,
+      authenticated: request.query.authenticated === 'true',
+    })
 
     return this.json(result.keyParams)
   }

--- a/src/Domain/UseCase/GetUserKeyParams/GetUserKeyParams.spec.ts
+++ b/src/Domain/UseCase/GetUserKeyParams/GetUserKeyParams.spec.ts
@@ -24,7 +24,7 @@ describe('GetUserKeyParams', () => {
   })
 
   it('should get key params for an authenticated user', async () => {
-    expect(await createUseCase().execute({ email: 'test@test.te', authenticatedUser: user })).toEqual({
+    expect(await createUseCase().execute({ email: 'test@test.te', authenticated: true, authenticatedUser: user })).toEqual({
       keyParams: {
         foo: 'bar',
       },
@@ -34,7 +34,7 @@ describe('GetUserKeyParams', () => {
   })
 
   it('should get key params for an unauthenticated user', async () => {
-    expect(await createUseCase().execute({ email: 'test@test.te' })).toEqual({
+    expect(await createUseCase().execute({ email: 'test@test.te', authenticated: false })).toEqual({
       keyParams: {
         foo: 'bar',
       },
@@ -46,7 +46,7 @@ describe('GetUserKeyParams', () => {
   it('should get pseudo key params for a non existing user', async () => {
     userRepository.findOneByEmail = jest.fn().mockReturnValue(undefined)
 
-    expect(await createUseCase().execute({ email: 'test@test.te' })).toEqual({
+    expect(await createUseCase().execute({ email: 'test@test.te', authenticated: false })).toEqual({
       keyParams: {
         bar: 'baz',
       },

--- a/src/Domain/UseCase/GetUserKeyParams/GetUserKeyParams.ts
+++ b/src/Domain/UseCase/GetUserKeyParams/GetUserKeyParams.ts
@@ -29,7 +29,7 @@ export class GetUserKeyParams implements UseCaseInterface {
     }
 
     return {
-      keyParams: this.keyParamsFactory.create(user, false),
+      keyParams: this.keyParamsFactory.create(user, dto.authenticated),
     }
   }
 }

--- a/src/Domain/UseCase/GetUserKeyParams/GetUserKeyParamsDTO.ts
+++ b/src/Domain/UseCase/GetUserKeyParams/GetUserKeyParamsDTO.ts
@@ -2,5 +2,6 @@ import { User } from '../../User/User'
 
 export type GetUserKeyParamsDTO = {
   email: string
+  authenticated: boolean
   authenticatedUser?: User
 }


### PR DESCRIPTION
need to pass this param from syncing-server-js-worker requests