### PR TITLE
feat: add getting user key params by uuid

### DIFF
--- a/src/Controller/UsersController.spec.ts
+++ b/src/Controller/UsersController.spec.ts
@@ -239,7 +239,7 @@ describe('UsersController', () => {
     expect(actual.json).toHaveProperty('error')
   })
 
-  it('should get user key params', async () => {
+  it('should get user key params by email', async () => {
     const subject = UsersControllerTest.makeSubject({
       updateUser,
       deleteAccount,
@@ -247,6 +247,31 @@ describe('UsersController', () => {
 
     Object.assign(request, {
       query: { email: 'test@test.com' },
+    })
+
+    const actual = await subject.keyParams(request)
+
+    expect(actual.statusCode).toEqual(200)
+    expect(actual.json).toEqual({
+      identifier: 'test@test.com',
+      version: '004',
+    })
+  })
+
+  it('should get user key params by uuid', async () => {
+    const user = UserTest.makeWithSettings()
+    const userUuid = user.uuid
+
+    const userRepository = new UserRepostioryStub([user])
+
+    const subject = UsersControllerTest.makeSubject({
+      updateUser,
+      deleteAccount,
+      userRepository,
+    })
+
+    Object.assign(request, {
+      query: { uuid: userUuid },
     })
 
     const actual = await subject.keyParams(request)
@@ -277,7 +302,7 @@ describe('UsersController', () => {
     })
   })
 
-  it('should error when email parameter is not given in query when gettting user key params', async () => {
+  it('should error when email and uuid parameters are not given in query when gettting user key params', async () => {
     const subject = UsersControllerTest.makeSubject({
       updateUser,
       deleteAccount,

--- a/src/Controller/UsersController.ts
+++ b/src/Controller/UsersController.ts
@@ -134,8 +134,9 @@ export class UsersController extends BaseHttpController {
   @httpGet('/params')
   async keyParams(request: Request): Promise<results.JsonResult> {
     const email = 'email' in request.query ? <string> request.query.email : undefined
+    const userUuid = 'uuid' in request.query ? <string> request.query.uuid : undefined
 
-    if(!email) {
+    if(!email && !userUuid) {
       return this.json({
         error: {
           message: 'Missing mandatory request query parameters.',
@@ -145,6 +146,7 @@ export class UsersController extends BaseHttpController {
 
     const result = await this.getUserKeyParams.execute({
       email,
+      userUuid,
       authenticated: request.query.authenticated === 'true',
     })
 

--- a/src/Domain/UseCase/GetUserKeyParams/GetUserKeyParams.spec.ts
+++ b/src/Domain/UseCase/GetUserKeyParams/GetUserKeyParams.spec.ts
@@ -23,12 +23,13 @@ describe('GetUserKeyParams', () => {
 
     userRepository = {} as jest.Mocked<UserRepositoryInterface>
     userRepository.findOneByEmail = jest.fn().mockReturnValue(user)
+    userRepository.findOneByUuid = jest.fn().mockReturnValue(user)
 
     logger = {} as jest.Mocked<Logger>
     logger.debug = jest.fn()
   })
 
-  it('should get key params for an authenticated user', async () => {
+  it('should get key params for an authenticated user - searching by email', async () => {
     expect(await createUseCase().execute({ email: 'test@test.te', authenticated: true, authenticatedUser: user })).toEqual({
       keyParams: {
         foo: 'bar',
@@ -38,7 +39,7 @@ describe('GetUserKeyParams', () => {
     expect(keyParamsFactory.create).toHaveBeenCalledWith(user, true)
   })
 
-  it('should get key params for an unauthenticated user', async () => {
+  it('should get key params for an unauthenticated user - searching by email', async () => {
     expect(await createUseCase().execute({ email: 'test@test.te', authenticated: false })).toEqual({
       keyParams: {
         foo: 'bar',
@@ -48,7 +49,27 @@ describe('GetUserKeyParams', () => {
     expect(keyParamsFactory.create).toHaveBeenCalledWith(user, false)
   })
 
-  it('should get pseudo key params for a non existing user', async () => {
+  it('should get key params for an authenticated user - searching by uuid', async () => {
+    expect(await createUseCase().execute({ userUuid: '1-2-3', authenticated: true, authenticatedUser: user })).toEqual({
+      keyParams: {
+        foo: 'bar',
+      },
+    })
+
+    expect(keyParamsFactory.create).toHaveBeenCalledWith(user, true)
+  })
+
+  it('should get key params for an unauthenticated user - searching by uuid', async () => {
+    expect(await createUseCase().execute({ userUuid: '1-2-3', authenticated: false })).toEqual({
+      keyParams: {
+        foo: 'bar',
+      },
+    })
+
+    expect(keyParamsFactory.create).toHaveBeenCalledWith(user, false)
+  })
+
+  it('should get pseudo key params for a non existing user - when searching by email', async () => {
     userRepository.findOneByEmail = jest.fn().mockReturnValue(undefined)
 
     expect(await createUseCase().execute({ email: 'test@test.te', authenticated: false })).toEqual({
@@ -58,5 +79,31 @@ describe('GetUserKeyParams', () => {
     })
 
     expect(keyParamsFactory.createPseudoParams).toHaveBeenCalledWith('test@test.te')
+  })
+
+  it('should throw error for a non existing user - when searching by uuid', async () => {
+    userRepository.findOneByUuid = jest.fn().mockReturnValue(undefined)
+
+    let error = null
+    try {
+      await createUseCase().execute({ userUuid: '1-2-3', authenticated: false })
+    } catch (e) {
+      error =e
+    }
+
+    expect(error).not.toBeNull()
+  })
+
+  it('should throw error for a non existing user - when search parameters are not given', async () => {
+    userRepository.findOneByUuid = jest.fn().mockReturnValue(undefined)
+
+    let error = null
+    try {
+      await createUseCase().execute({ authenticated: false })
+    } catch (e) {
+      error =e
+    }
+
+    expect(error).not.toBeNull()
   })
 })

--- a/src/Domain/UseCase/GetUserKeyParams/GetUserKeyParamsDTO.ts
+++ b/src/Domain/UseCase/GetUserKeyParams/GetUserKeyParamsDTO.ts
@@ -1,7 +1,8 @@
 import { User } from '../../User/User'
 
 export type GetUserKeyParamsDTO = {
-  email: string
+  email?: string
+  userUuid?: string
   authenticated: boolean
   authenticatedUser?: User
 }


### PR DESCRIPTION
an alternative for getting the user key params by uuid is required from the syncing-server-js worker perspective