### PR TITLE
feat: retrieving and saving mfa

### DIFF
--- a/src/Bootstrap/Container.ts
+++ b/src/Bootstrap/Container.ts
@@ -85,6 +85,7 @@ import { WebSocketsConnectionRepositoryInterface } from '../Domain/WebSockets/We
 import { RedisWebSocketsConnectionRepository } from '../Infra/Redis/RedisWebSocketsConnectionRepository'
 import { AddWebSocketsConnection } from '../Domain/UseCase/AddWebSocketsConnection/AddWebSocketsConnection'
 import { RemoveWebSocketsConnection } from '../Domain/UseCase/RemoveWebSocketsConnection/RemoveWebSocketsConnection'
+import { GetMFASetting } from '../Domain/UseCase/GetMFASetting/GetMFASetting'
 
 export class ContainerConfigLoader {
   async load(): Promise<Container> {
@@ -233,6 +234,7 @@ export class ContainerConfigLoader {
     container.bind<ChangePassword>(TYPES.ChangePassword).to(ChangePassword)
     container.bind<GetSettings>(TYPES.GetSettings).to(GetSettings)
     container.bind<GetSetting>(TYPES.GetSetting).to(GetSetting)
+    container.bind<GetMFASetting>(TYPES.GetMFASetting).to(GetMFASetting)
     container.bind<UpdateSetting>(TYPES.UpdateSetting).to(UpdateSetting)
     container.bind<DeleteSetting>(TYPES.DeleteSetting).to(DeleteSetting)
     container.bind<GetAuthMethods>(TYPES.GetAuthMethods).to(GetAuthMethods)

--- a/src/Bootstrap/Types.ts
+++ b/src/Bootstrap/Types.ts
@@ -66,6 +66,7 @@ const TYPES = {
   ChangePassword: Symbol.for('ChangePassword'),
   GetSettings: Symbol.for('GetSettings'),
   GetSetting: Symbol.for('GetSetting'),
+  GetMFASetting: Symbol.for('GetMFASetting'),
   UpdateSetting: Symbol.for('UpdateSetting'),
   DeleteSetting: Symbol.for('DeleteSetting'),
   GetAuthMethods: Symbol.for('GetAuthMethods'),

--- a/src/Controller/UsersController.ts
+++ b/src/Controller/UsersController.ts
@@ -127,7 +127,7 @@ export class UsersController extends BaseHttpController {
     })
 
     if (result.success) {
-      return this.statusCode(result.statusCode)
+      return this.json({ setting: result.setting }, result.statusCode)
     }
 
     return this.json(result, 400)

--- a/src/Controller/UsersController.ts
+++ b/src/Controller/UsersController.ts
@@ -14,6 +14,7 @@ import TYPES from '../Bootstrap/Types'
 import { Setting } from '../Domain/Setting/Setting'
 import { DeleteAccount } from '../Domain/UseCase/DeleteAccount/DeleteAccount'
 import { DeleteSetting } from '../Domain/UseCase/DeleteSetting/DeleteSetting'
+import { GetMFASetting } from '../Domain/UseCase/GetMFASetting/GetMFASetting'
 import { GetSetting } from '../Domain/UseCase/GetSetting/GetSetting'
 import { GetSettings } from '../Domain/UseCase/GetSettings/GetSettings'
 import { GetUserKeyParams } from '../Domain/UseCase/GetUserKeyParams/GetUserKeyParams'
@@ -26,6 +27,7 @@ export class UsersController extends BaseHttpController {
     @inject(TYPES.UpdateUser) private updateUser: UpdateUser,
     @inject(TYPES.GetSettings) private doGetSettings: GetSettings,
     @inject(TYPES.GetSetting) private doGetSetting: GetSetting,
+    @inject(TYPES.GetMFASetting) private doGetMFASetting: GetMFASetting,
     @inject(TYPES.GetUserKeyParams) private getUserKeyParams: GetUserKeyParams,
     @inject(TYPES.UpdateSetting) private doUpdateSetting: UpdateSetting,
     @inject(TYPES.DeleteAccount) private doDeleteAccount: DeleteAccount,
@@ -76,6 +78,25 @@ export class UsersController extends BaseHttpController {
     const result = await this.doGetSettings.execute({ userUuid })
 
     return this.json(result)
+  }
+
+  @httpGet('/:userUuid/mfa', TYPES.AuthMiddleware)
+  async getMFASetting(request: Request, response: Response): Promise<results.JsonResult> {
+    if (request.params.userUuid !== response.locals.user.uuid) {
+      return this.json({
+        error: {
+          message: 'Operation not allowed.',
+        },
+      }, 401)
+    }
+
+    const result = await this.doGetMFASetting.execute({ userUuid: request.params.userUuid })
+
+    if (result.success) {
+      return this.json(result)
+    }
+
+    return this.json(result, 400)
   }
 
   @httpGet('/:userUuid/settings/:settingName', TYPES.AuthMiddleware)

--- a/src/Controller/test/UsersControllerTest.ts
+++ b/src/Controller/test/UsersControllerTest.ts
@@ -17,6 +17,7 @@ import { UserRepositoryInterface } from '../../Domain/User/UserRepositoryInterfa
 import { SettingProjector } from '../../Projection/SettingProjector'
 import { SettingProjectorTest } from '../../Projection/test/SettingProjectorTest'
 import { UsersController } from '../UsersController'
+import { GetMFASettingTest } from '../../Domain/UseCase/GetMFASetting/test/GetMFASettingTest'
 
 export class UsersControllerTest {
   static makeSubject({
@@ -47,6 +48,10 @@ export class UsersControllerTest {
         projector,
       }),
       GetSettingTest.makeSubject({
+        repository: settingRepository,
+        projector,
+      }),
+      GetMFASettingTest.makeSubject({
         repository: settingRepository,
         projector,
       }),

--- a/src/Domain/Setting/CreateOrReplaceSettingResponse.ts
+++ b/src/Domain/Setting/CreateOrReplaceSettingResponse.ts
@@ -1,0 +1,6 @@
+import { Setting } from './Setting'
+
+export type CreateOrReplaceSettingResponse = {
+  status: 'created' | 'replaced'
+  setting: Setting
+}

--- a/src/Domain/Setting/CreateOrReplaceSettingStatus.ts
+++ b/src/Domain/Setting/CreateOrReplaceSettingStatus.ts
@@ -1,1 +1,0 @@
-export type CreateOrReplaceSettingStatus = 'created' | 'replaced'

--- a/src/Domain/Setting/SettingService.spec.ts
+++ b/src/Domain/Setting/SettingService.spec.ts
@@ -4,7 +4,7 @@ import { SettingServiceTest as SettingServiceTest } from './test/SettingServiceT
 import { SettingTest } from './test/SettingTest'
 
 describe('SettingService', () => {
-  it('should create setting if it doesn\'t exist', async () => {
+  it ('should create setting if it doesn\'t exist', async () => {
     const persister = SettingServiceTest.makeSubject()
     const user = UserTest.makeSubject({})
 
@@ -17,9 +17,10 @@ describe('SettingService', () => {
       },
     })
 
-    expect(result).toEqual('created')
+    expect(result.status).toEqual('created')
   })
-  it('should replace setting if it does exist', async () => {
+
+  it ('should replace setting if it does exist', async () => {
     const user = UserTest.makeSubject({})
     const setting = SettingTest.makeSubject({}, user)
     const persister = SettingServiceTest.makeSubject({
@@ -35,6 +36,6 @@ describe('SettingService', () => {
       },
     })
 
-    expect(result).toEqual('replaced')
+    expect(result.status).toEqual('replaced')
   })
 })

--- a/src/Domain/Setting/SettingService.ts
+++ b/src/Domain/Setting/SettingService.ts
@@ -1,7 +1,7 @@
 import { inject, injectable } from 'inversify'
 import TYPES from '../../Bootstrap/Types'
 import { CreateOrReplaceSettingDto } from './CreateOrReplaceSettingDto'
-import { CreateOrReplaceSettingStatus } from './CreateOrReplaceSettingStatus'
+import { CreateOrReplaceSettingResponse } from './CreateOrReplaceSettingResponse'
 import { SettingFactory } from './SettingFactory'
 import { SettingRepositoryInterface } from './SettingRepositoryInterface'
 
@@ -13,19 +13,25 @@ export class SettingService {
   ) {}
 
   async createOrReplace(dto: CreateOrReplaceSettingDto):
-  Promise<CreateOrReplaceSettingStatus> {
+  Promise<CreateOrReplaceSettingResponse> {
     const { user, props } = dto
 
     const existing = await this.repository.findOneByNameAndUserUuid(props.name, user.uuid)
 
     if (existing === undefined) {
-      await this.repository.save(await this.factory.create(props, user))
+      const setting = await this.repository.save(await this.factory.create(props, user))
 
-      return 'created'
+      return {
+        status: 'created',
+        setting,
+      }
     }
 
-    await this.repository.save(await this.factory.createReplacement(existing, props))
+    const setting = await this.repository.save(await this.factory.createReplacement(existing, props))
 
-    return 'replaced'
+    return {
+      status: 'replaced',
+      setting,
+    }
   }
 }

--- a/src/Domain/UseCase/GetMFASetting/GetMFASetting.spec.ts
+++ b/src/Domain/UseCase/GetMFASetting/GetMFASetting.spec.ts
@@ -1,0 +1,50 @@
+import 'reflect-metadata'
+import { SettingProjectorTest } from '../../../Projection/test/SettingProjectorTest'
+import { Setting } from '../../Setting/Setting'
+import { SimpleSetting } from '../../Setting/SimpleSetting'
+import { UserTest } from '../../User/test/UserTest'
+import { GetMFASettingTest } from './test/GetMFASettingTest'
+
+describe('GetMFASetting', () => {
+  const user = UserTest.makeSubject({
+    uuid: 'user-with-settings-uuid',
+  }, {
+    settings: [
+      { uuid: 'setting-2-uuid', name: 'MFA_SECRET' },
+      { uuid: 'setting-2-uuid', name: 'setting-2-name' },
+      { uuid: 'setting-3-uuid', name: 'setting-3-name' },
+    ],
+  })
+  const userUuid = user.uuid
+  const settingIndex = 0
+
+  const projector = SettingProjectorTest.get()
+
+  let settings: Setting[]
+  let simpleSettings: SimpleSetting[]
+  beforeEach(async () => {
+    settings = await user.settings
+    simpleSettings = await projector.projectManySimple(settings)
+  })
+
+  const makeSubject = () => GetMFASettingTest.makeSubject({
+    settings,
+    projector,
+  })
+
+  it('should get an mfa setting with a valid user uuid', async () => {
+    const actual = await makeSubject().execute({ userUuid })
+
+    expect(actual).toEqual({
+      success: true,
+      userUuid,
+      setting: simpleSettings[settingIndex],
+    })
+  })
+
+  it('should fail for invalid user uuid', async () => {
+    const actual = await makeSubject().execute({ userUuid: 'BAD' })
+
+    expect(actual.success).toEqual(false)
+  })
+})

--- a/src/Domain/UseCase/GetMFASetting/GetMFASetting.ts
+++ b/src/Domain/UseCase/GetMFASetting/GetMFASetting.ts
@@ -1,0 +1,39 @@
+import { inject, injectable } from 'inversify'
+import { GetMFASettingDto } from './GetMFASettingDto'
+import { GetMFASettingResponse } from './GetMFASettingResponse'
+import { UseCaseInterface } from '../UseCaseInterface'
+import TYPES from '../../../Bootstrap/Types'
+import { SettingProjector } from '../../../Projection/SettingProjector'
+import { SettingRepositoryInterface } from '../../Setting/SettingRepositoryInterface'
+import { SETTINGS } from '../../Setting/Settings'
+
+@injectable()
+export class GetMFASetting implements UseCaseInterface {
+  constructor (
+    @inject(TYPES.SettingRepository) private settingRepository: SettingRepositoryInterface,
+    @inject(TYPES.SettingProjector) private settingProjector: SettingProjector,
+  ) {}
+
+  async execute(dto: GetMFASettingDto): Promise<GetMFASettingResponse> {
+    const { userUuid } = dto
+
+    const setting = await this.settingRepository.findOneByNameAndUserUuid(SETTINGS.MFA_SECRET, userUuid)
+
+    if (setting === undefined) {
+      return {
+        success: false,
+        error: {
+          message: `Setting ${SETTINGS.MFA_SECRET} for user ${userUuid} not found!`,
+        },
+      }
+    }
+
+    const simpleSetting = await this.settingProjector.projectSimple(setting)
+
+    return {
+      success: true,
+      userUuid,
+      setting: simpleSetting,
+    }
+  }
+}

--- a/src/Domain/UseCase/GetMFASetting/GetMFASettingDto.ts
+++ b/src/Domain/UseCase/GetMFASetting/GetMFASettingDto.ts
@@ -1,0 +1,5 @@
+import { Uuid } from '@standardnotes/auth'
+
+export type GetMFASettingDto = {
+  userUuid: Uuid
+}

--- a/src/Domain/UseCase/GetMFASetting/GetMFASettingResponse.ts
+++ b/src/Domain/UseCase/GetMFASetting/GetMFASettingResponse.ts
@@ -1,0 +1,13 @@
+import { SimpleSetting } from '../../Setting/SimpleSetting'
+import { Uuid } from '@standardnotes/auth'
+
+export type GetMFASettingResponse = {
+  success: true,
+  userUuid: Uuid,
+  setting: SimpleSetting,
+} | {
+  success: false,
+  error: {
+    message: string,
+  },
+}

--- a/src/Domain/UseCase/GetMFASetting/test/GetMFASettingTest.ts
+++ b/src/Domain/UseCase/GetMFASetting/test/GetMFASettingTest.ts
@@ -1,0 +1,23 @@
+import { SettingProjector } from '../../../../Projection/SettingProjector'
+import { SettingProjectorTest } from '../../../../Projection/test/SettingProjectorTest'
+import { Setting } from '../../../Setting/Setting'
+import { SettingRepositoryInterface } from '../../../Setting/SettingRepositoryInterface'
+import { SettingRepostioryStub } from '../../../Setting/test/SettingRepositoryStub'
+import { GetMFASetting } from '../GetMFASetting'
+
+export class GetMFASettingTest {
+  static makeSubject({
+    settings = [],
+    repository = new SettingRepostioryStub(settings),
+    projector = SettingProjectorTest.get(),
+  }: {
+    settings?: Setting[],
+    repository?: SettingRepositoryInterface,
+    projector?: SettingProjector,
+  } = {}): GetMFASetting {
+    return new GetMFASetting(
+      repository,
+      projector,
+    )
+  }
+}

--- a/src/Domain/UseCase/UpdateSetting/UpdateSetting.spec.ts
+++ b/src/Domain/UseCase/UpdateSetting/UpdateSetting.spec.ts
@@ -1,5 +1,4 @@
 import 'reflect-metadata'
-import { Setting } from '../../Setting/Setting'
 import { UserTest } from '../../User/test/UserTest'
 import { UserRepositoryInterface } from '../../User/UserRepositoryInterface'
 import { UpdateSettingTest } from './test/UpdateSettingTest'
@@ -32,7 +31,11 @@ describe('UpdateSetting', () => {
 
     expect(actual).toEqual({
       success: true,
-      setting: expect.any(Setting),
+      setting: {
+        name: 'test-setting-name',
+        uuid: expect.any(String),
+        value: 'test-setting-value',
+      },
       statusCode: 201,
     })
   })
@@ -52,7 +55,11 @@ describe('UpdateSetting', () => {
 
     expect(actual).toEqual({
       success: true,
-      setting: expect.any(Setting),
+      setting: {
+        name: 'setting-1-name',
+        uuid: expect.any(String),
+        value: 'REPLACED',
+      },
       statusCode: 204,
     })
   })

--- a/src/Domain/UseCase/UpdateSetting/UpdateSetting.spec.ts
+++ b/src/Domain/UseCase/UpdateSetting/UpdateSetting.spec.ts
@@ -1,4 +1,5 @@
 import 'reflect-metadata'
+import { Setting } from '../../Setting/Setting'
 import { UserTest } from '../../User/test/UserTest'
 import { UserRepositoryInterface } from '../../User/UserRepositoryInterface'
 import { UpdateSettingTest } from './test/UpdateSettingTest'
@@ -31,6 +32,7 @@ describe('UpdateSetting', () => {
 
     expect(actual).toEqual({
       success: true,
+      setting: expect.any(Setting),
       statusCode: 201,
     })
   })
@@ -50,6 +52,7 @@ describe('UpdateSetting', () => {
 
     expect(actual).toEqual({
       success: true,
+      setting: expect.any(Setting),
       statusCode: 204,
     })
   })

--- a/src/Domain/UseCase/UpdateSetting/UpdateSetting.ts
+++ b/src/Domain/UseCase/UpdateSetting/UpdateSetting.ts
@@ -28,14 +28,15 @@ export class UpdateSetting implements UseCaseInterface {
       }
     }
 
-    const status = await this.settingService.createOrReplace({
+    const response = await this.settingService.createOrReplace({
       user,
       props,
     })
 
     return {
       success: true,
-      statusCode: this.statusToStatusCode(status),
+      setting: response.setting,
+      statusCode: this.statusToStatusCode(response),
     }
   }
 

--- a/src/Domain/UseCase/UpdateSetting/UpdateSetting.ts
+++ b/src/Domain/UseCase/UpdateSetting/UpdateSetting.ts
@@ -6,11 +6,13 @@ import TYPES from '../../../Bootstrap/Types'
 import { UserRepositoryInterface } from '../../User/UserRepositoryInterface'
 import { CreateOrReplaceSettingResponse } from '../../Setting/CreateOrReplaceSettingResponse'
 import { SettingService } from '../../Setting/SettingService'
+import { SettingProjector } from '../../../Projection/SettingProjector'
 
 @injectable()
 export class UpdateSetting implements UseCaseInterface {
   constructor (
     @inject(TYPES.SettingService) private settingService: SettingService,
+    @inject(TYPES.SettingProjector) private settingProjector: SettingProjector,
     @inject(TYPES.UserRepository) private userRepository: UserRepositoryInterface,
   ) {}
 
@@ -35,7 +37,7 @@ export class UpdateSetting implements UseCaseInterface {
 
     return {
       success: true,
-      setting: response.setting,
+      setting: await this.settingProjector.projectSimple(response.setting),
       statusCode: this.statusToStatusCode(response),
     }
   }

--- a/src/Domain/UseCase/UpdateSetting/UpdateSetting.ts
+++ b/src/Domain/UseCase/UpdateSetting/UpdateSetting.ts
@@ -4,7 +4,7 @@ import { UpdateSettingResponse } from './UpdateSettingResponse'
 import { UseCaseInterface } from '../UseCaseInterface'
 import TYPES from '../../../Bootstrap/Types'
 import { UserRepositoryInterface } from '../../User/UserRepositoryInterface'
-import { CreateOrReplaceSettingStatus } from '../../Setting/CreateOrReplaceSettingStatus'
+import { CreateOrReplaceSettingResponse } from '../../Setting/CreateOrReplaceSettingResponse'
 import { SettingService } from '../../Setting/SettingService'
 
 @injectable()
@@ -40,15 +40,15 @@ export class UpdateSetting implements UseCaseInterface {
   }
 
   /* istanbul ignore next */
-  private statusToStatusCode(status: CreateOrReplaceSettingStatus): number {
-    if (status === 'created') {
+  private statusToStatusCode(response: CreateOrReplaceSettingResponse): number {
+    if (response.status === 'created') {
       return 201
     }
-    if (status === 'replaced') {
+    if (response.status === 'replaced') {
       return 204
     }
 
-    const exhaustiveCheck: never = status
+    const exhaustiveCheck: never = response.status
     throw new Error(`Unrecognized status: ${exhaustiveCheck}!`)
   }
 }

--- a/src/Domain/UseCase/UpdateSetting/UpdateSettingResponse.ts
+++ b/src/Domain/UseCase/UpdateSetting/UpdateSettingResponse.ts
@@ -1,5 +1,8 @@
+import { Setting } from '../../Setting/Setting'
+
 export type UpdateSettingResponse = {
   success: true,
+  setting: Setting,
   statusCode: number,
 } | {
   success: false,

--- a/src/Domain/UseCase/UpdateSetting/UpdateSettingResponse.ts
+++ b/src/Domain/UseCase/UpdateSetting/UpdateSettingResponse.ts
@@ -1,8 +1,8 @@
-import { Setting } from '../../Setting/Setting'
+import { SimpleSetting } from '../../Setting/SimpleSetting'
 
 export type UpdateSettingResponse = {
   success: true,
-  setting: Setting,
+  setting: SimpleSetting,
   statusCode: number,
 } | {
   success: false,

--- a/src/Domain/UseCase/UpdateSetting/test/UpdateSettingTest.ts
+++ b/src/Domain/UseCase/UpdateSetting/test/UpdateSettingTest.ts
@@ -1,3 +1,5 @@
+import { SettingProjector } from '../../../../Projection/SettingProjector'
+import { SettingProjectorTest } from '../../../../Projection/test/SettingProjectorTest'
 import { Setting } from '../../../Setting/Setting'
 import { SettingService } from '../../../Setting/SettingService'
 import { SettingServiceTest } from '../../../Setting/test/SettingServiceTest'
@@ -8,14 +10,17 @@ export class UpdateSettingTest {
   static makeSubject({
     settings = [],
     settingService = SettingServiceTest.makeSubject({ settings }),
+    projector = SettingProjectorTest.get(),
     userRepository,
   }: {
     settings?: Setting[],
     settingService?: SettingService,
+    projector?: SettingProjector,
     userRepository: UserRepositoryInterface,
   }): UpdateSetting {
     return new UpdateSetting(
       settingService,
+      projector,
       userRepository,
     )
   }


### PR DESCRIPTION
this PR adds responding with the MFA setting object upon creation/udpate and also adds an internal endpoint for retrieving MFA for a given user (to be used only from ssjs perspective)