### PR TITLE
feat: send user role changed webSockets event

### DIFF
--- a/bin/worker.ts
+++ b/bin/worker.ts
@@ -2,6 +2,9 @@ import 'reflect-metadata'
 
 import 'newrelic'
 
+import * as dayjs from 'dayjs'
+import * as utc from 'dayjs/plugin/utc'
+
 import { Logger } from 'winston'
 
 import { ContainerConfigLoader } from '../src/Bootstrap/Container'
@@ -11,6 +14,8 @@ import { DomainEventSubscriberFactoryInterface } from '@standardnotes/domain-eve
 
 const container = new ContainerConfigLoader
 void container.load().then(container => {
+  dayjs.extend(utc)
+
   const env: Env = new Env()
   env.load()
 

--- a/src/Bootstrap/Container.ts
+++ b/src/Bootstrap/Container.ts
@@ -92,6 +92,7 @@ import { ContentDecoder } from '../Domain/Encryption/ContentDecoder'
 import axios, { AxiosInstance } from 'axios'
 import { UserSubscription } from '../Domain/User/UserSubscription'
 import { MySQLUserSubscriptionRepository } from '../Infra/MySQL/MySQLUserSubscriptionRepository'
+import { WebSocketsService } from '../Domain/WebSockets/WebSocketsService'
 
 export class ContainerConfigLoader {
   async load(): Promise<Container> {
@@ -224,6 +225,7 @@ export class ContainerConfigLoader {
     container.bind(TYPES.REDIS_EVENTS_CHANNEL).toConstantValue(env.get('REDIS_EVENTS_CHANNEL'))
     container.bind(TYPES.NEW_RELIC_ENABLED).toConstantValue(env.get('NEW_RELIC_ENABLED', true))
     container.bind(TYPES.SYNCING_SERVER_URL).toConstantValue(env.get('SYNCING_SERVER_URL'))
+    container.bind(TYPES.WEBSOCKETS_API_URL).toConstantValue(env.get('WEBSOCKETS_API_URL'))
 
     // use cases
     container.bind<AuthenticateUser>(TYPES.AuthenticateUser).to(AuthenticateUser)
@@ -274,6 +276,7 @@ export class ContainerConfigLoader {
     container.bind<TimerInterface>(TYPES.Timer).toConstantValue(new Timer())
     container.bind<ItemHttpServiceInterface>(TYPES.ItemHttpService).to(SyncingServerHttpService)
     container.bind<ContentDecoderInterface>(TYPES.ContenDecoder).to(ContentDecoder)
+    container.bind<WebSocketsService>(TYPES.WebSocketsService).to(WebSocketsService)
 
     if (env.get('SNS_TOPIC_ARN', true)) {
       container.bind<SNSDomainEventPublisher>(TYPES.DomainEventPublisher).toConstantValue(

--- a/src/Bootstrap/Types.ts
+++ b/src/Bootstrap/Types.ts
@@ -50,6 +50,7 @@ const TYPES = {
   REDIS_EVENTS_CHANNEL: Symbol.for('REDIS_EVENTS_CHANNEL'),
   NEW_RELIC_ENABLED: Symbol.for('NEW_RELIC_ENABLED'),
   SYNCING_SERVER_URL: Symbol.for('SYNCING_SERVER_URL'),
+  WEBSOCKETS_API_URL: Symbol.for('WEBSOCKETS_API_URL'),
   // use cases
   AuthenticateUser: Symbol.for('AuthenticateUser'),
   AuthenticateRequest: Symbol.for('AuthenticateRequest'),
@@ -101,6 +102,7 @@ const TYPES = {
   Timer: Symbol.for('Timer'),
   ItemHttpService: Symbol.for('ItemHttpService'),
   ContenDecoder: Symbol.for('ContenDecoder'),
+  WebSocketsService: Symbol.for('WebSocketService'),
 }
 
 export default TYPES

--- a/src/Domain/Event/DomainEventFactory.spec.ts
+++ b/src/Domain/Event/DomainEventFactory.spec.ts
@@ -1,3 +1,4 @@
+import { RoleName } from '@standardnotes/auth'
 import 'reflect-metadata'
 
 import { DomainEventFactory } from './DomainEventFactory'
@@ -25,6 +26,21 @@ describe('DomainEventFactory', () => {
           userUuid: '1-2-3',
         },
         type: 'ACCOUNT_DELETION_REQUESTED',
+      })
+  })
+
+  it('should create a USER_ROLE_CHANGED event', () => {
+    expect(createFactory().createUserRoleChangedEvent('1-2-3', 'test@test.com', RoleName.CoreUser, RoleName.ProUser))
+      .toEqual({
+        createdAt: expect.any(Date),
+        payload: {
+          userUuid: '1-2-3',
+          email: 'test@test.com',
+          fromRole: RoleName.CoreUser,
+          toRole: RoleName.ProUser,
+          timestamp: expect.any(Number),
+        },
+        type: 'USER_ROLE_CHANGED',
       })
   })
 })

--- a/src/Domain/Event/DomainEventFactory.ts
+++ b/src/Domain/Event/DomainEventFactory.ts
@@ -1,4 +1,5 @@
-import { AccountDeletionRequestedEvent, UserRegisteredEvent } from '@standardnotes/domain-events'
+import { RoleName } from '@standardnotes/auth'
+import { AccountDeletionRequestedEvent, UserRegisteredEvent, UserRoleChangedEvent } from '@standardnotes/domain-events'
 import * as dayjs from 'dayjs'
 import { injectable } from 'inversify'
 import { DomainEventFactoryInterface } from './DomainEventFactoryInterface'
@@ -22,6 +23,20 @@ export class DomainEventFactory implements DomainEventFactoryInterface {
       payload: {
         userUuid,
         email,
+      },
+    }
+  }
+
+  createUserRoleChangedEvent(userUuid: string, email: string, fromRole: RoleName, toRole: RoleName): UserRoleChangedEvent {
+    return {
+      type: 'USER_ROLE_CHANGED',
+      createdAt: dayjs.utc().toDate(),
+      payload: {
+        userUuid,
+        email,
+        fromRole,
+        toRole,
+        timestamp: dayjs.utc().valueOf(),
       },
     }
   }

--- a/src/Domain/Event/DomainEventFactoryInterface.ts
+++ b/src/Domain/Event/DomainEventFactoryInterface.ts
@@ -1,6 +1,7 @@
-import { AccountDeletionRequestedEvent, UserRegisteredEvent } from '@standardnotes/domain-events'
+import { AccountDeletionRequestedEvent, UserRegisteredEvent, UserRoleChangedEvent } from '@standardnotes/domain-events'
 
 export interface DomainEventFactoryInterface {
   createUserRegisteredEvent(userUuid: string, email: string): UserRegisteredEvent
   createAccountDeletionRequestedEvent(userUuid: string): AccountDeletionRequestedEvent
+  createUserRoleChangedEvent(userUuid: string, email: string, fromRole: string, toRole: string): UserRoleChangedEvent
 }

--- a/src/Domain/Handler/SubscriptionPurchasedEventHandler.spec.ts
+++ b/src/Domain/Handler/SubscriptionPurchasedEventHandler.spec.ts
@@ -95,7 +95,11 @@ describe('SubscriptionPurchasedEventHandler', () => {
     expect(userRepository.findOneByEmail).toHaveBeenCalledWith('test@test.com')
     expect(
       userSubscriptionRepository.save
-    ).toHaveBeenCalledWith(expect.objectContaining(subscription))
+    ).toHaveBeenCalledWith({
+      ...subscription,
+      createdAt: expect.any(Number),
+      updatedAt: expect.any(Number),
+    })
   })
 
   it('should send websockets event', async () => {

--- a/src/Domain/Handler/SubscriptionPurchasedEventHandler.ts
+++ b/src/Domain/Handler/SubscriptionPurchasedEventHandler.ts
@@ -15,7 +15,7 @@ import { User } from '../User/User'
 import { UserRepositoryInterface } from '../User/UserRepositoryInterface'
 import { UserSubscription } from '../User/UserSubscription'
 import { UserSubscriptionRepositoryInterface } from '../User/UserSubscriptionRepositoryInterface'
-import { WebSocketServiceInterface } from '../WebSockets/WebSocketsServiceInterface'
+import { WebSocketsServiceInterface } from '../WebSockets/WebSocketsServiceInterface'
 
 @injectable()
 export class SubscriptionPurchasedEventHandler
@@ -25,7 +25,7 @@ implements DomainEventHandlerInterface
     @inject(TYPES.UserRepository) private userRepository: UserRepositoryInterface,
     @inject(TYPES.RoleRepository) private roleRepository: RoleRepositoryInterface,
     @inject(TYPES.UserSubscriptionRepository) private userSubscriptionRepository: UserSubscriptionRepositoryInterface,
-    @inject(TYPES.WebSocketsService) private webSocketsService: WebSocketServiceInterface,
+    @inject(TYPES.WebSocketsService) private webSocketsService: WebSocketsServiceInterface,
     @inject(TYPES.Logger) private logger: Logger
   ) {}
 

--- a/src/Domain/Handler/SubscriptionPurchasedEventHandler.ts
+++ b/src/Domain/Handler/SubscriptionPurchasedEventHandler.ts
@@ -43,7 +43,6 @@ implements DomainEventHandlerInterface
       event.payload.subscriptionName,
       user,
       event.payload.subscriptionExpiresAt,
-      event.payload.timestamp,
     )
     await this.updateUserRole(user, event.payload.subscriptionName)
   }
@@ -82,13 +81,12 @@ implements DomainEventHandlerInterface
     subscriptionName: string,
     user: User,
     subscriptionExpiresAt: number,
-    timestamp: number,
   ): Promise<void> {
     const subscription = new UserSubscription()
     subscription.planName = subscriptionName
     subscription.user = Promise.resolve(user)
-    subscription.createdAt = timestamp
-    subscription.updatedAt = timestamp
+    subscription.createdAt = dayjs.utc().valueOf()
+    subscription.updatedAt = dayjs.utc().valueOf()
     subscription.endsAt = subscriptionExpiresAt
 
     await this.userSubscriptionRepository.save(subscription)

--- a/src/Domain/Handler/SubscriptionRefundedEventHandler.ts
+++ b/src/Domain/Handler/SubscriptionRefundedEventHandler.ts
@@ -11,7 +11,7 @@ import { RoleRepositoryInterface } from '../Role/RoleRepositoryInterface'
 import { User } from '../User/User'
 import { UserRepositoryInterface } from '../User/UserRepositoryInterface'
 import { UserSubscriptionRepositoryInterface } from '../User/UserSubscriptionRepositoryInterface'
-import { WebSocketServiceInterface } from '../WebSockets/WebSocketsServiceInterface'
+import { WebSocketsServiceInterface } from '../WebSockets/WebSocketsServiceInterface'
 
 @injectable()
 export class SubscriptionRefundedEventHandler
@@ -21,7 +21,7 @@ implements DomainEventHandlerInterface
     @inject(TYPES.UserRepository) private userRepository: UserRepositoryInterface,
     @inject(TYPES.RoleRepository) private roleRepository: RoleRepositoryInterface,
     @inject(TYPES.UserSubscriptionRepository) private userSubscriptionRepository: UserSubscriptionRepositoryInterface,
-    @inject(TYPES.WebSocketsService) private webSocketsService: WebSocketServiceInterface,
+    @inject(TYPES.WebSocketsService) private webSocketsService: WebSocketsServiceInterface,
     @inject(TYPES.Logger) private logger: Logger
   ) {}
 

--- a/src/Domain/Handler/SubscriptionRenewedEventHandler.spec.ts
+++ b/src/Domain/Handler/SubscriptionRenewedEventHandler.spec.ts
@@ -62,7 +62,6 @@ describe('SubscriptionRenewedEventHandler', () => {
       SubscriptionName.ProPlan,
       '123',
       subscriptionExpirationDate,
-      timestamp
     )
   })
 

--- a/src/Domain/Handler/SubscriptionRenewedEventHandler.ts
+++ b/src/Domain/Handler/SubscriptionRenewedEventHandler.ts
@@ -37,7 +37,6 @@ implements DomainEventHandlerInterface
       event.payload.subscriptionName,
       user.uuid,
       event.payload.subscriptionExpiresAt,
-      event.payload.timestamp,
     )
   }
 
@@ -45,13 +44,11 @@ implements DomainEventHandlerInterface
     subscriptionName: string,
     userUuid: string,
     subscriptionExpiresAt: number,
-    timestamp: number,
   ): Promise<void> {
     await this.userSubscriptionRepository.updateEndsAtByNameAndUserUuid(
       subscriptionName,
       userUuid,
       subscriptionExpiresAt,
-      timestamp,
     )
   }
 }

--- a/src/Domain/User/UserSubscriptionRepositoryInterface.ts
+++ b/src/Domain/User/UserSubscriptionRepositoryInterface.ts
@@ -1,6 +1,6 @@
 import { UserSubscription } from './UserSubscription'
 
 export interface UserSubscriptionRepositoryInterface {
-  updateEndsAtByNameAndUserUuid(name: string, userUuid: string, endsAt: number, updatedAt: number): Promise<void>
+  updateEndsAtByNameAndUserUuid(name: string, userUuid: string, endsAt: number): Promise<void>
   save(subscription: UserSubscription): Promise<UserSubscription> 
 }

--- a/src/Domain/WebSockets/WebSocketService.spec.ts
+++ b/src/Domain/WebSockets/WebSocketService.spec.ts
@@ -1,0 +1,68 @@
+import 'reflect-metadata'
+
+import { UserRoleChangedEvent } from '@standardnotes/domain-events'
+import { User } from '../User/User'
+import { RoleName } from '@standardnotes/auth'
+
+import { WebSocketsService } from './WebSocketsService'
+import { WebSocketsConnectionRepositoryInterface } from './WebSocketsConnectionRepositoryInterface'
+import { DomainEventFactoryInterface } from '../Event/DomainEventFactoryInterface'
+import { AxiosInstance } from 'axios'
+
+describe('WebSocketsService', () => {
+  let connectionIds: string[]
+  let user: User
+  let fromRole: RoleName
+  let toRole: RoleName
+  let event: UserRoleChangedEvent
+  let webSocketsConnectionRepository: WebSocketsConnectionRepositoryInterface
+  let domainEventFactory: DomainEventFactoryInterface
+  let httpClient: AxiosInstance
+  
+  const webSocketsApiUrl = 'http://test-websockets'
+
+  const createService = () => new WebSocketsService(
+    webSocketsConnectionRepository,
+    domainEventFactory,
+    httpClient,
+    webSocketsApiUrl,
+  )
+
+  beforeEach(() => {
+    connectionIds = ['1', '2']
+
+    user = {
+      uuid: '123',
+      email: 'test@test.com',
+    } as jest.Mocked<User>
+
+    fromRole = RoleName.CoreUser
+    toRole = RoleName.ProUser
+
+    event = {} as jest.Mocked<UserRoleChangedEvent>
+
+    webSocketsConnectionRepository = {} as jest.Mocked<WebSocketsConnectionRepositoryInterface>
+    webSocketsConnectionRepository.findAllByUserUuid = jest.fn().mockReturnValue(connectionIds)
+
+    domainEventFactory = {} as jest.Mocked<DomainEventFactoryInterface>
+    domainEventFactory.createUserRoleChangedEvent = jest.fn().mockReturnValue(event)
+
+    httpClient = {} as jest.Mocked<AxiosInstance>
+    httpClient.request = jest.fn()
+  })
+
+  describe('send user role changed event', () => {
+    it('should send a user role changed event to all user connections', async () => {
+      await createService().sendUserRoleChangedEvent(user, fromRole, toRole)
+
+      expect(httpClient.request).toHaveBeenCalledTimes(connectionIds.length)
+      connectionIds.map((id, index) => {
+        expect(httpClient.request).toHaveBeenNthCalledWith(index + 1, expect.objectContaining({
+          method: 'POST',
+          url: `${webSocketsApiUrl}/${id}`,
+          data: JSON.stringify(event),
+        }))
+      })
+    })
+  })
+})

--- a/src/Domain/WebSockets/WebSocketsConnectionRepositoryInterface.ts
+++ b/src/Domain/WebSockets/WebSocketsConnectionRepositoryInterface.ts
@@ -1,4 +1,5 @@
 export interface WebSocketsConnectionRepositoryInterface {
-  saveConnection (userUuid: string, connectionId: string): Promise<void>
-  removeConnection (connectionId: string): Promise<void>
+  findAllByUserUuid(userUuid: string): Promise<string[]>
+  saveConnection(userUuid: string, connectionId: string): Promise<void>
+  removeConnection(connectionId: string): Promise<void>
 }

--- a/src/Domain/WebSockets/WebSocketsService.ts
+++ b/src/Domain/WebSockets/WebSocketsService.ts
@@ -33,7 +33,7 @@ export class WebSocketsService implements WebSocketsServiceInterface {
     )
 
     await Promise.all(
-      userConnections.map(async (connectionUuid) => {
+      userConnections.map(async (connectionUuid) => (
         await this.httpClient.request({
           method: 'POST',
           url: `${this.webSocketsApiUrl}/${connectionUuid}`,
@@ -46,7 +46,7 @@ export class WebSocketsService implements WebSocketsServiceInterface {
             /* istanbul ignore next */
             (status: number) => status >= 200 && status < 500,
         })
-      })
+      ))
     )
   }
 }

--- a/src/Domain/WebSockets/WebSocketsService.ts
+++ b/src/Domain/WebSockets/WebSocketsService.ts
@@ -1,0 +1,52 @@
+import { RoleName } from '@standardnotes/auth'
+import { AxiosInstance } from 'axios'
+import { inject, injectable } from 'inversify'
+
+import TYPES from '../../Bootstrap/Types'
+import { DomainEventFactoryInterface } from '../Event/DomainEventFactoryInterface'
+import { User } from '../User/User'
+import { WebSocketsConnectionRepositoryInterface } from './WebSocketsConnectionRepositoryInterface'
+import { WebSocketServiceInterface } from './WebSocketsServiceInterface'
+
+@injectable()
+export class WebSocketsService implements WebSocketServiceInterface {
+  constructor(
+    @inject(TYPES.WebSocketsConnectionRepository) private webSocketsConnectionRepository: WebSocketsConnectionRepositoryInterface,
+    @inject(TYPES.DomainEventFactory) private domainEventFactory: DomainEventFactoryInterface,
+    @inject(TYPES.HTTPClient) private httpClient: AxiosInstance,
+    @inject(TYPES.WEBSOCKETS_API_URL) private webSocketsApiUrl: string,
+  ) {}
+
+  async sendUserRoleChangedEvent(
+    user: User,
+    fromRole: RoleName,
+    toRole: RoleName,
+  ): Promise<void> {
+    const userConnections =
+      await this.webSocketsConnectionRepository.findAllByUserUuid(user.uuid)
+    
+    const event = this.domainEventFactory.createUserRoleChangedEvent(
+      user.uuid,
+      user.email,
+      fromRole,
+      toRole
+    )
+
+    await Promise.all(
+      userConnections.map(async (connectionUuid) => {
+        await this.httpClient.request({
+          method: 'POST',
+          url: `${this.webSocketsApiUrl}/${connectionUuid}`,
+          headers: {
+            Accept: 'text/plain',
+            'Content-Type': 'text/plain',
+          },
+          data: JSON.stringify(event),
+          validateStatus:
+            /* istanbul ignore next */
+            (status: number) => status >= 200 && status < 500,
+        })
+      })
+    )
+  }
+}

--- a/src/Domain/WebSockets/WebSocketsService.ts
+++ b/src/Domain/WebSockets/WebSocketsService.ts
@@ -6,10 +6,10 @@ import TYPES from '../../Bootstrap/Types'
 import { DomainEventFactoryInterface } from '../Event/DomainEventFactoryInterface'
 import { User } from '../User/User'
 import { WebSocketsConnectionRepositoryInterface } from './WebSocketsConnectionRepositoryInterface'
-import { WebSocketServiceInterface } from './WebSocketsServiceInterface'
+import { WebSocketsServiceInterface } from './WebSocketsServiceInterface'
 
 @injectable()
-export class WebSocketsService implements WebSocketServiceInterface {
+export class WebSocketsService implements WebSocketsServiceInterface {
   constructor(
     @inject(TYPES.WebSocketsConnectionRepository) private webSocketsConnectionRepository: WebSocketsConnectionRepositoryInterface,
     @inject(TYPES.DomainEventFactory) private domainEventFactory: DomainEventFactoryInterface,

--- a/src/Domain/WebSockets/WebSocketsServiceInterface.ts
+++ b/src/Domain/WebSockets/WebSocketsServiceInterface.ts
@@ -1,6 +1,6 @@
 import { RoleName } from '@standardnotes/auth'
 import { User } from '../User/User'
 
-export interface WebSocketServiceInterface {
+export interface WebSocketsServiceInterface {
   sendUserRoleChangedEvent(user: User, fromRole: RoleName, toRole: RoleName): Promise<void>
 }

--- a/src/Domain/WebSockets/WebSocketsServiceInterface.ts
+++ b/src/Domain/WebSockets/WebSocketsServiceInterface.ts
@@ -1,0 +1,6 @@
+import { RoleName } from '@standardnotes/auth'
+import { User } from '../User/User'
+
+export interface WebSocketServiceInterface {
+  sendUserRoleChangedEvent(user: User, fromRole: RoleName, toRole: RoleName): Promise<void>
+}

--- a/src/Infra/MySQL/MySQLUserSubscriptionRepository.spec.ts
+++ b/src/Infra/MySQL/MySQLUserSubscriptionRepository.spec.ts
@@ -29,9 +29,10 @@ describe('MySQLUserSubscriptionRepository', () => {
 
     expect(queryBuilder.update).toHaveBeenCalled()
     expect(queryBuilder.set).toHaveBeenCalledWith(
-      expect.objectContaining({
+      {
+        updatedAt: expect.any(Number),
         endsAt: 1000,
-      })
+      }
     )
     expect(queryBuilder.where).toHaveBeenCalledWith(
       'plan_name = :plan_name AND user_uuid = :user_uuid',

--- a/src/Infra/MySQL/MySQLUserSubscriptionRepository.spec.ts
+++ b/src/Infra/MySQL/MySQLUserSubscriptionRepository.spec.ts
@@ -25,14 +25,13 @@ describe('MySQLUserSubscriptionRepository', () => {
     queryBuilder.where = jest.fn().mockReturnThis()
     queryBuilder.execute = jest.fn()
 
-    await repository.updateEndsAtByNameAndUserUuid('test', '123', 1000, 1000)
+    await repository.updateEndsAtByNameAndUserUuid('test', '123', 1000)
 
     expect(queryBuilder.update).toHaveBeenCalled()
     expect(queryBuilder.set).toHaveBeenCalledWith(
-      {
+      expect.objectContaining({
         endsAt: 1000,
-        updatedAt: 1000,
-      }
+      })
     )
     expect(queryBuilder.where).toHaveBeenCalledWith(
       'plan_name = :plan_name AND user_uuid = :user_uuid',

--- a/src/Infra/MySQL/MySQLUserSubscriptionRepository.ts
+++ b/src/Infra/MySQL/MySQLUserSubscriptionRepository.ts
@@ -1,18 +1,20 @@
 import { injectable } from 'inversify'
 import { EntityRepository, Repository } from 'typeorm'
 
+import * as dayjs from 'dayjs'
+
 import { UserSubscription } from '../../Domain/User/UserSubscription'
 import { UserSubscriptionRepositoryInterface } from '../../Domain/User/UserSubscriptionRepositoryInterface'
 
 @injectable()
 @EntityRepository(UserSubscription)
 export class MySQLUserSubscriptionRepository extends Repository<UserSubscription> implements UserSubscriptionRepositoryInterface {
-  async updateEndsAtByNameAndUserUuid(name: string, userUuid: string, endsAt: number, updatedAt: number): Promise<void> {
+  async updateEndsAtByNameAndUserUuid(name: string, userUuid: string, endsAt: number): Promise<void> {
     await this.createQueryBuilder()
       .update()
       .set({
         endsAt,
-        updatedAt,
+        updatedAt: dayjs.utc().valueOf(),
       })
       .where(
         'plan_name = :plan_name AND user_uuid = :user_uuid',

--- a/src/Infra/Redis/RedisWebSocketsConnectionRepository.spec.ts
+++ b/src/Infra/Redis/RedisWebSocketsConnectionRepository.spec.ts
@@ -16,6 +16,7 @@ describe('RedisWebSocketsConnectionRepository', () => {
     redisClient.get = jest.fn()
     redisClient.srem = jest.fn()
     redisClient.del = jest.fn()
+    redisClient.smembers = jest.fn()
   })
 
   it('should save a connection to set of user connections', async () => {
@@ -32,5 +33,12 @@ describe('RedisWebSocketsConnectionRepository', () => {
 
     expect(redisClient.srem).toHaveBeenCalledWith('ws_user_connections:1-2-3', '2-3-4')
     expect(redisClient.del).toHaveBeenCalledWith('ws_connection:2-3-4')
+  })
+
+  it('should return all connections for a user uuid', async () => {
+    const userUuid = '1-2-3'
+
+    await createRepository().findAllByUserUuid(userUuid)
+    expect(redisClient.smembers).toHaveBeenCalledWith(`ws_user_connections:${userUuid}`)
   })
 })

--- a/src/Infra/Redis/RedisWebSocketsConnectionRepository.ts
+++ b/src/Infra/Redis/RedisWebSocketsConnectionRepository.ts
@@ -13,6 +13,10 @@ export class RedisWebSocketsConnectionRepository implements WebSocketsConnection
   ) {
   }
 
+  async findAllByUserUuid(userUuid: string): Promise<string[]> {
+    return await this.redisClient.smembers(`${this.WEB_SOCKETS_USER_CONNECTIONS_PREFIX}:${userUuid}`)
+  }
+
   async removeConnection(connectionId: string): Promise<void> {
     const userUuid = await this.redisClient.get(`${this.WEB_SOCKETS_CONNETION_PREFIX}:${connectionId}`)
 
@@ -20,7 +24,7 @@ export class RedisWebSocketsConnectionRepository implements WebSocketsConnection
     await this.redisClient.del(`${this.WEB_SOCKETS_CONNETION_PREFIX}:${connectionId}`)
   }
 
-  async saveConnection (userUuid: string, connectionId: string): Promise<void> {
+  async saveConnection(userUuid: string, connectionId: string): Promise<void> {
     await this.redisClient.set(`${this.WEB_SOCKETS_CONNETION_PREFIX}:${connectionId}`, userUuid)
     await this.redisClient.sadd(`${this.WEB_SOCKETS_USER_CONNECTIONS_PREFIX}:${userUuid}`, connectionId)
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -676,10 +676,10 @@
     "@typescript-eslint/eslint-plugin" "^4.14.0"
     "@typescript-eslint/parser" "^4.14.0"
 
-"@standardnotes/domain-events@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@standardnotes/domain-events/-/domain-events-1.3.0.tgz#237eabf174c71cbef9bfbfcfd83d4dae23aedf07"
-  integrity sha512-jrGxPZVAGpHv/qSAbcW5JTSWpZ2D5KW0LwsR0cq1BeUL1EQwUtIDJ+0d9ckw/FVA9FIqZUGePYo+a4wZoFql7w==
+"@standardnotes/domain-events@1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@standardnotes/domain-events/-/domain-events-1.4.1.tgz#f370c8cc88c6017881c1b49a4ed4f2ccde29d031"
+  integrity sha512-/evc7G8FSEoxL5rt4RoC56vsmBZ1warkYJqMIwNhQfNmrWf9VHIsarSrg9fzqHIzL0OqfEvWotmI70j0UPX8GQ==
   dependencies:
     "@standardnotes/auth" "^3.2.0"
     aws-sdk "^2.824.0"


### PR DESCRIPTION
- feat: add user role changed event to event factory
- feat: add websockets service
- feat: use current time instead of timestamp when updating db
- feat: send user role changed event on handlers
- fix: web sockets service interface name
- tests: update tests
- tests: add websockets service test
- fix: websockets event loop
- tests: add websockets connection repository test
- tests: add domain event factory test
- fix: use expect any for dates and timestamps
