### PR TITLE
feat: admin controller

### DIFF
--- a/bin/server.ts
+++ b/bin/server.ts
@@ -8,6 +8,7 @@ import '../src/Controller/SessionsController'
 import '../src/Controller/AuthController'
 import '../src/Controller/UsersController'
 import '../src/Controller/WebSocketsController'
+import '../src/Controller/AdminController'
 
 import * as cors from 'cors'
 import { urlencoded, json, Request, Response, NextFunction } from 'express'

--- a/src/Controller/AdminController.spec.ts
+++ b/src/Controller/AdminController.spec.ts
@@ -1,0 +1,67 @@
+import 'reflect-metadata'
+
+import { AdminController } from './AdminController'
+import { results } from 'inversify-express-utils'
+import { User } from '../Domain/User/User'
+import { UserRepositoryInterface } from '../Domain/User/UserRepositoryInterface'
+import * as express from 'express'
+
+describe('AdminController', () => {
+  let userRepository: UserRepositoryInterface
+  let request: express.Request
+  let user: User
+
+  const createController = () => new AdminController(
+    userRepository,
+  )
+
+  beforeEach(() => {
+    user = {} as jest.Mocked<User>
+    user.uuid = '123'
+
+    userRepository = {} as jest.Mocked<UserRepositoryInterface>
+    userRepository.findOneByEmail = jest.fn().mockReturnValue(user)
+
+    request = {
+      headers: {},
+      body: {},
+      params: {},
+    } as jest.Mocked<express.Request>
+  })
+
+  it('should return error if missing email parameter', async () => {
+    const httpResponse = await createController().getUser(request)
+    const result = await httpResponse.executeAsync()
+
+    expect(httpResponse).toBeInstanceOf(results.JsonResult)
+
+    expect(result.statusCode).toBe(400)
+    expect(await result.content.readAsStringAsync()).toEqual('{"error":{"message":"Missing email parameter."}}')
+  })
+
+  it('should return error if no user with such email exists', async () => {
+    request.params.email = 'test@sn.org'
+
+    userRepository.findOneByEmail = jest.fn().mockReturnValue(null)
+
+    const httpResponse = await createController().getUser(request)
+    const result = await httpResponse.executeAsync()
+
+    expect(httpResponse).toBeInstanceOf(results.JsonResult)
+
+    expect(result.statusCode).toBe(400)
+    expect(await result.content.readAsStringAsync()).toEqual('{"error":{"message":"No user with email \'test@sn.org\'."}}')
+  })
+
+  it('should return the user\'s uuid', async () => {
+    request.params.email = 'test@sn.org'
+
+    const httpResponse = await createController().getUser(request)
+    const result = await httpResponse.executeAsync()
+
+    expect(httpResponse).toBeInstanceOf(results.JsonResult)
+
+    expect(result.statusCode).toBe(200)
+    expect(await result.content.readAsStringAsync()).toEqual('{"uuid":"123"}')
+  })
+})

--- a/src/Controller/AdminController.ts
+++ b/src/Controller/AdminController.ts
@@ -1,0 +1,47 @@
+import { Request } from 'express'
+import { inject } from 'inversify'
+import {
+  BaseHttpController,
+  controller,
+  httpGet,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  results,
+} from 'inversify-express-utils'
+import TYPES from '../Bootstrap/Types'
+import { UserRepositoryInterface } from '../Domain/User/UserRepositoryInterface'
+
+@controller('/admin')
+export class AdminController extends BaseHttpController {
+  constructor(
+    @inject(TYPES.UserRepository) private userRepository: UserRepositoryInterface,
+  ) {
+    super()
+  }
+
+  @httpGet('/user/:email')
+  async getUser(request: Request): Promise<results.JsonResult> {
+    const email = 'email' in request.params ? <string> request.params.email : undefined
+
+    if(!email) {
+      return this.json({
+        error: {
+          message: 'Missing email parameter.',
+        },
+      }, 400)
+    }
+
+    const user = await this.userRepository.findOneByEmail(email)
+
+    if (!user) {
+      return this.json({
+        error: {
+          message: `No user with email '${email}'.`,
+        },
+      }, 400)
+    }
+
+    return this.json({
+      uuid: user.uuid,
+    })
+  }
+}


### PR DESCRIPTION
- endpoint `/admin/user/:email` returns user info (only `uuid` for now)