### PR TITLE
feat: add sensitive settings

### DIFF
--- a/migrations/1629705289178-add_sensitive_flag.ts
+++ b/migrations/1629705289178-add_sensitive_flag.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class addSensitiveFlag1629705289178 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE `settings` ADD `sensitive` tinyint NOT NULL DEFAULT 0')
+
+    await queryRunner.query('UPDATE `settings` SET sensitive = 1 WHERE name = "MFA_SECRET"')
+    await queryRunner.query('UPDATE `settings` SET sensitive = 1 WHERE name = "EXTENSION_KEY"')
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE `settings` DROP COLUMN `sensitive`')
+  }
+}

--- a/src/Controller/UsersController.spec.ts
+++ b/src/Controller/UsersController.spec.ts
@@ -172,7 +172,7 @@ describe('UsersController', () => {
     const httpResponse = <results.JsonResult> await createController().getMFASettings(request)
     const result = await httpResponse.executeAsync()
 
-    expect(getSettings.execute).toHaveBeenCalledWith({ userUuid: '1-2-3', settingName: 'MFA_SECRET', allowMFARetrieval: true, updatedAfter: 123 })
+    expect(getSettings.execute).toHaveBeenCalledWith({ userUuid: '1-2-3', settingName: 'MFA_SECRET', allowSensitiveRetrieval: true, updatedAfter: 123 })
 
     expect(result.statusCode).toEqual(200)
   })
@@ -185,7 +185,7 @@ describe('UsersController', () => {
     const httpResponse = <results.JsonResult> await createController().getMFASettings(request)
     const result = await httpResponse.executeAsync()
 
-    expect(getSettings.execute).toHaveBeenCalledWith({ userUuid: '1-2-3', settingName: 'MFA_SECRET', allowMFARetrieval: true })
+    expect(getSettings.execute).toHaveBeenCalledWith({ userUuid: '1-2-3', settingName: 'MFA_SECRET', allowSensitiveRetrieval: true })
 
     expect(result.statusCode).toEqual(400)
   })
@@ -235,6 +235,7 @@ describe('UsersController', () => {
         createdAt: 123,
         name: 'MFA_SECRET',
         serverEncryptionVersion: Setting.ENCRYPTION_VERSION_CLIENT_ENCODED_AND_SERVER_ENCRYPTED,
+        sensitive: true,
         updatedAt: 234,
         uuid: '2-3-4',
         value: 'test',
@@ -250,6 +251,7 @@ describe('UsersController', () => {
     request.body = {
       uuid: '2-3-4',
       value: 'test',
+      sensitive: true,
       serverEncryptionVersion: Setting.ENCRYPTION_VERSION_DEFAULT,
       createdAt: 123,
       updatedAt: 234,
@@ -266,6 +268,7 @@ describe('UsersController', () => {
         name: 'MFA_SECRET',
         serverEncryptionVersion: 1,
         updatedAt: 234,
+        sensitive: true,
         uuid: '2-3-4',
         value: 'test',
       },
@@ -298,6 +301,7 @@ describe('UsersController', () => {
         updatedAt: 234,
         uuid: '2-3-4',
         value: 'test',
+        sensitive: true,
       },
       userUuid: '1-2-3',
     })
@@ -375,6 +379,7 @@ describe('UsersController', () => {
     expect(updateSetting.execute).toHaveBeenCalledWith({
       props: {
         name: 'foo',
+        sensitive: false,
         serverEncryptionVersion: 1,
         value: 'bar',
       },
@@ -404,6 +409,7 @@ describe('UsersController', () => {
     expect(updateSetting.execute).toHaveBeenCalledWith({
       props: {
         name: 'foo',
+        sensitive: false,
         serverEncryptionVersion: 0,
         value: 'bar',
       },
@@ -456,6 +462,7 @@ describe('UsersController', () => {
       props: {
         name: 'foo',
         serverEncryptionVersion: 1,
+        sensitive: false,
         value: 'bar',
       },
       userUuid: '1-2-3',

--- a/src/Controller/UsersController.ts
+++ b/src/Controller/UsersController.ts
@@ -86,7 +86,7 @@ export class UsersController extends BaseHttpController {
     const result = await this.doGetSettings.execute({
       userUuid: request.params.userUuid,
       settingName: SettingName.MfaSecret,
-      allowMFARetrieval: true,
+      allowSensitiveRetrieval: true,
       updatedAfter: request.body.lastSyncTime,
     })
 
@@ -134,6 +134,7 @@ export class UsersController extends BaseHttpController {
       name: SettingName.MfaSecret,
       createdAt,
       updatedAt,
+      sensitive: true,
     }
 
     const { userUuid } = request.params
@@ -183,12 +184,14 @@ export class UsersController extends BaseHttpController {
       name,
       value,
       serverEncryptionVersion = Setting.ENCRYPTION_VERSION_DEFAULT,
+      sensitive = false,
     } = request.body
 
     const props = {
       name,
       value,
       serverEncryptionVersion,
+      sensitive,
     }
 
     const { userUuid } = request.params

--- a/src/Domain/Handler/ExtensionKeyGrantedEventHandler.spec.ts
+++ b/src/Domain/Handler/ExtensionKeyGrantedEventHandler.spec.ts
@@ -60,6 +60,7 @@ describe('ExtensionKeyGrantedEventHandler', () => {
         name: 'EXTENSION_KEY',
         serverEncryptionVersion: 1,
         value: 'abc123',
+        sensitive: true,
       },
       user: {
         uuid: '123',

--- a/src/Domain/Handler/ExtensionKeyGrantedEventHandler.ts
+++ b/src/Domain/Handler/ExtensionKeyGrantedEventHandler.ts
@@ -38,6 +38,7 @@ export class ExtensionKeyGrantedEventHandler implements DomainEventHandlerInterf
         name: SettingName.ExtensionKey,
         value: event.payload.extensionKey,
         serverEncryptionVersion: Setting.ENCRYPTION_VERSION_DEFAULT,
+        sensitive: true,
       },
     })
   }

--- a/src/Domain/Setting/Setting.ts
+++ b/src/Domain/Setting/Setting.ts
@@ -52,4 +52,12 @@ export class Setting {
   )
   @JoinColumn({ name: 'user_uuid', referencedColumnName: 'uuid' })
   user: Promise<User>
+
+  @Column({
+    type: 'tinyint',
+    width: 1,
+    nullable: false,
+    default: 0,
+  })
+  sensitive: boolean
 }

--- a/src/Domain/Setting/SettingFactory.spec.ts
+++ b/src/Domain/Setting/SettingFactory.spec.ts
@@ -28,6 +28,7 @@ describe('SettingFactory', () => {
       name: 'name',
       value: 'value',
       serverEncryptionVersion: Setting.ENCRYPTION_VERSION_UNENCRYPTED,
+      sensitive: false,
     }
     const actual = await createFactory().create(props, user)
 
@@ -35,6 +36,7 @@ describe('SettingFactory', () => {
       createdAt: 1,
       updatedAt: 1,
       name: 'name',
+      sensitive: false,
       serverEncryptionVersion: 0,
       user: Promise.resolve(user),
       uuid: expect.any(String),
@@ -50,6 +52,7 @@ describe('SettingFactory', () => {
       name: 'name',
       value: 'value2',
       serverEncryptionVersion: Setting.ENCRYPTION_VERSION_UNENCRYPTED,
+      sensitive: true,
     }
 
     const actual = await createFactory().createReplacement(original, props)
@@ -58,6 +61,7 @@ describe('SettingFactory', () => {
       createdAt: 1,
       updatedAt: 1,
       name: 'name',
+      sensitive: true,
       serverEncryptionVersion: 0,
       user: Promise.resolve(user),
       uuid: '2-3-4',
@@ -70,6 +74,7 @@ describe('SettingFactory', () => {
     const props: SettingProps = {
       name: 'name',
       value,
+      sensitive: false,
     }
 
     const actual = await createFactory()
@@ -79,6 +84,7 @@ describe('SettingFactory', () => {
       createdAt: 1,
       updatedAt: 1,
       name: 'name',
+      sensitive: false,
       serverEncryptionVersion: 1,
       user: Promise.resolve(user),
       uuid: expect.any(String),
@@ -92,6 +98,7 @@ describe('SettingFactory', () => {
       name: 'name',
       value,
       serverEncryptionVersion: 99999999999,
+      sensitive: false,
     }
 
     await expect(async () => await createFactory()

--- a/src/Domain/Setting/SettingFactory.ts
+++ b/src/Domain/Setting/SettingFactory.ts
@@ -24,6 +24,7 @@ export class SettingFactory {
       name,
       value,
       serverEncryptionVersion = Setting.ENCRYPTION_VERSION_DEFAULT,
+      sensitive,
     } = props
 
     const setting: Setting = {
@@ -38,6 +39,7 @@ export class SettingFactory {
       serverEncryptionVersion,
       createdAt,
       updatedAt,
+      sensitive,
     }
 
     return Object.assign(new Setting(), setting)

--- a/src/Domain/Setting/SettingService.spec.ts
+++ b/src/Domain/Setting/SettingService.spec.ts
@@ -51,6 +51,7 @@ describe('SettingService', () => {
         name: 'name',
         value: 'value',
         serverEncryptionVersion: 1,
+        sensitive: false,
       },
     })
 
@@ -67,6 +68,7 @@ describe('SettingService', () => {
         name: 'name',
         value: 'value',
         serverEncryptionVersion: 1,
+        sensitive: false,
       },
     })
 

--- a/src/Domain/UseCase/GetSetting/GetSetting.spec.ts
+++ b/src/Domain/UseCase/GetSetting/GetSetting.spec.ts
@@ -1,3 +1,4 @@
+import { SettingName } from '@standardnotes/settings'
 import 'reflect-metadata'
 import { SettingProjector } from '../../../Projection/SettingProjector'
 import { Setting } from '../../Setting/Setting'
@@ -41,17 +42,29 @@ describe('GetSetting', () => {
     })
   })
 
-  it('should not find an mfa setting for user', async () => {
-    expect(await createUseCase().execute({ userUuid: '1-2-3', settingName: 'MFA_SECRET' })).toEqual({
-      success: false,
-      error: {
-        message: 'Setting MFA_SECRET for user 1-2-3 not found!',
-      },
+  it('should not retrieve a sensitive setting for user', async () => {
+    setting = {
+      sensitive: true,
+      name: SettingName.MfaSecret,
+    } as jest.Mocked<Setting>
+
+    settingService.findSetting = jest.fn().mockReturnValue(setting)
+
+    expect(await createUseCase().execute({ userUuid: '1-2-3', settingName: SettingName.MfaSecret })).toEqual({
+      success: true,
+      sensitive: true,
     })
   })
 
-  it('should find an mfa setting for user if explicitly told to', async () => {
-    expect(await createUseCase().execute({ userUuid: '1-2-3', settingName: 'MFA_SECRET', allowMFARetrieval: true })).toEqual({
+  it('should retrieve a sensitive setting for user if explicitly told to', async () => {
+    setting = {
+      sensitive: true,
+      name: SettingName.MfaSecret,
+    } as jest.Mocked<Setting>
+
+    settingService.findSetting = jest.fn().mockReturnValue(setting)
+
+    expect(await createUseCase().execute({ userUuid: '1-2-3', settingName: 'MFA_SECRET', allowSensitiveRetrieval: true })).toEqual({
       success: true,
       userUuid: '1-2-3',
       setting: { foo: 'bar' },

--- a/src/Domain/UseCase/GetSetting/GetSetting.ts
+++ b/src/Domain/UseCase/GetSetting/GetSetting.ts
@@ -18,15 +18,6 @@ export class GetSetting implements UseCaseInterface {
   async execute(dto: GetSettingDto): Promise<GetSettingResponse> {
     const { userUuid, settingName } = dto
 
-    if (settingName === SettingName.MfaSecret && !dto.allowMFARetrieval) {
-      return {
-        success: false,
-        error: {
-          message: `Setting ${settingName} for user ${userUuid} not found!`,
-        },
-      }
-    }
-
     const setting = await this.settingService.findSetting({
       userUuid,
       settingName: settingName as SettingName,
@@ -38,6 +29,13 @@ export class GetSetting implements UseCaseInterface {
         error: {
           message: `Setting ${settingName} for user ${userUuid} not found!`,
         },
+      }
+    }
+
+    if (setting.sensitive && !dto.allowSensitiveRetrieval) {
+      return {
+        success: true,
+        sensitive: true,
       }
     }
 

--- a/src/Domain/UseCase/GetSetting/GetSettingDto.ts
+++ b/src/Domain/UseCase/GetSetting/GetSettingDto.ts
@@ -3,5 +3,5 @@ import { Uuid } from '@standardnotes/common'
 export type GetSettingDto = {
   userUuid: Uuid,
   settingName: string,
-  allowMFARetrieval?: boolean
+  allowSensitiveRetrieval?: boolean
 }

--- a/src/Domain/UseCase/GetSetting/GetSettingResponse.ts
+++ b/src/Domain/UseCase/GetSetting/GetSettingResponse.ts
@@ -7,6 +7,9 @@ export type GetSettingResponse = {
   userUuid: Uuid,
   setting: SimpleSetting,
 } | {
+  success: true,
+  sensitive: true
+} | {
   success: false,
   error: {
     message: string,

--- a/src/Domain/UseCase/GetSettings/GetSettings.spec.ts
+++ b/src/Domain/UseCase/GetSettings/GetSettings.spec.ts
@@ -26,8 +26,14 @@ describe('GetSettings', () => {
     setting = {
       name: 'test',
       updatedAt: 345,
+      sensitive: false,
     } as jest.Mocked<Setting>
-    mfaSetting = { name: SettingName.MfaSecret, updatedAt: 122 } as jest.Mocked<Setting>
+
+    mfaSetting = {
+      name: SettingName.MfaSecret,
+      updatedAt: 122,
+      sensitive: true,
+    } as jest.Mocked<Setting>
 
     settingRepository = {} as jest.Mocked<SettingRepositoryInterface>
     settingRepository.findAllByUserUuid = jest.fn().mockReturnValue([ setting, mfaSetting ])
@@ -89,7 +95,7 @@ describe('GetSettings', () => {
   })
 
   it('should return all user settings of certain name', async () => {
-    expect(await createUseCase().execute({ userUuid: '1-2-3', settingName: 'test', allowMFARetrieval: true })).toEqual({
+    expect(await createUseCase().execute({ userUuid: '1-2-3', settingName: 'test', allowSensitiveRetrieval: true })).toEqual({
       success: true,
       userUuid: '1-2-3',
       settings: [{ foo: 'bar' }],
@@ -99,7 +105,7 @@ describe('GetSettings', () => {
   })
 
   it('should return all user settings updated after', async () => {
-    expect(await createUseCase().execute({ userUuid: '1-2-3', allowMFARetrieval: true, updatedAfter: 123 })).toEqual({
+    expect(await createUseCase().execute({ userUuid: '1-2-3', allowSensitiveRetrieval: true, updatedAfter: 123 })).toEqual({
       success: true,
       userUuid: '1-2-3',
       settings: [{ foo: 'bar' }],
@@ -108,8 +114,8 @@ describe('GetSettings', () => {
     expect(settingProjector.projectManySimple).toHaveBeenCalledWith([ setting ])
   })
 
-  it('should return all user settings with mfa if explicit', async () => {
-    expect(await createUseCase().execute({ userUuid: '1-2-3', allowMFARetrieval: true })).toEqual({
+  it('should return all sensitive user settings if explicit', async () => {
+    expect(await createUseCase().execute({ userUuid: '1-2-3', allowSensitiveRetrieval: true })).toEqual({
       success: true,
       userUuid: '1-2-3',
       settings: [{ foo: 'bar' }],

--- a/src/Domain/UseCase/GetSettings/GetSettings.ts
+++ b/src/Domain/UseCase/GetSettings/GetSettings.ts
@@ -1,5 +1,3 @@
-import { SettingName } from '@standardnotes/settings'
-
 import { inject, injectable } from 'inversify'
 import { GetSettingsDto } from './GetSettingsDto'
 import { GetSettingsResponse } from './GetSettingsResponse'
@@ -45,8 +43,8 @@ export class GetSettings implements UseCaseInterface {
       settings = settings.filter((setting: Setting) => setting.updatedAt >= (dto.updatedAfter as number))
     }
 
-    if (!dto.allowMFARetrieval) {
-      settings = settings.filter((setting: Setting) => setting.name !== SettingName.MfaSecret)
+    if (!dto.allowSensitiveRetrieval) {
+      settings = settings.filter((setting: Setting) => !setting.sensitive)
     }
 
     for (const setting of settings) {

--- a/src/Domain/UseCase/GetSettings/GetSettingsDto.ts
+++ b/src/Domain/UseCase/GetSettings/GetSettingsDto.ts
@@ -3,6 +3,6 @@ import { Uuid } from '@standardnotes/common'
 export type GetSettingsDto = {
   userUuid: Uuid,
   settingName?: string
-  allowMFARetrieval?: boolean
+  allowSensitiveRetrieval?: boolean
   updatedAfter?: number
 }

--- a/src/Domain/UseCase/UpdateSetting/UpdateSetting.spec.ts
+++ b/src/Domain/UseCase/UpdateSetting/UpdateSetting.spec.ts
@@ -43,6 +43,7 @@ describe('UpdateSetting', () => {
       name: 'test-setting-name',
       value: 'test-setting-value',
       serverEncryptionVersion: Setting.ENCRYPTION_VERSION_UNENCRYPTED,
+      sensitive: false,
     }
 
     const response = await createUseCase().execute({ props, userUuid: '1-2-3' })
@@ -52,6 +53,7 @@ describe('UpdateSetting', () => {
         name: 'test-setting-name',
         value: 'test-setting-value',
         serverEncryptionVersion: 0,
+        sensitive: false,
       },
       user,
     })
@@ -70,6 +72,7 @@ describe('UpdateSetting', () => {
       name: 'test-setting-name',
       value: 'test-setting-value',
       serverEncryptionVersion: Setting.ENCRYPTION_VERSION_UNENCRYPTED,
+      sensitive: false,
     }
 
     const response = await createUseCase().execute({ props, userUuid: '1-2-3' })


### PR DESCRIPTION
This adds the option indicate that a setting is sensitive and should not be retrievable (unless forced).

This works well for `MFA_SECRET` and `EXTENSION_KEY` settings that should not be retrieved via HTTP controller. So when trying to retrieve them the response would be `{ success: true, sensitive: true }` - this indicates that the setting is present in the db but it's not possible to retrieve it via HTTP calls for security reasons.