### PR TITLE
Fix offline concurrency issue

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,24 @@
-# Description
+## PR Type
+What kind of change does this PR introduce?
 
-Please include a summary of the change and internal link if possible.
+- [ ] Bugfix
+- [ ] Feature
+- [ ] Code style update (formatting, local variables)
+- [ ] Refactoring (no functional changes, no api changes)
+- [ ] Build related changes
+- [ ] CI related changes
+- [ ] Documentation content changes
+- [ ] Tests
+- [ ] Other
 
-Internal link:
+## Description
+
+<!--- describe what's new here -->
+
+## Related Issue(s)
+
+Internal link: <!--- place task link here -->
+
+## Production Ready?
+
+- [ ] This is ready to go out to production ASAP

--- a/src/Domain/Handler/SubscriptionExpiredEventHandler.spec.ts
+++ b/src/Domain/Handler/SubscriptionExpiredEventHandler.spec.ts
@@ -52,7 +52,6 @@ describe('SubscriptionExpiredEventHandler', () => {
 
     roleService = {} as jest.Mocked<RoleServiceInterface>
     roleService.removeUserRole = jest.fn()
-    roleService.removeOfflineUserRole = jest.fn()
 
     timestamp = dayjs.utc().valueOf()
 
@@ -76,14 +75,6 @@ describe('SubscriptionExpiredEventHandler', () => {
 
     expect(userRepository.findOneByEmail).toHaveBeenCalledWith('test@test.com')
     expect(roleService.removeUserRole).toHaveBeenCalledWith(user, SubscriptionName.CorePlan)
-  })
-
-  it('should update the offline user role', async () => {
-    event.payload.offline = true
-
-    await createHandler().handle(event)
-
-    expect(roleService.removeOfflineUserRole).toHaveBeenCalledWith('test@test.com', SubscriptionName.CorePlan)
   })
 
   it('should update subscription ends at', async () => {

--- a/src/Domain/Handler/SubscriptionExpiredEventHandler.ts
+++ b/src/Domain/Handler/SubscriptionExpiredEventHandler.ts
@@ -33,7 +33,6 @@ implements DomainEventHandlerInterface
         event.payload.subscriptionId,
         event.payload.timestamp,
       )
-      await this.removeOfflineUserRole(event.payload.userEmail, event.payload.subscriptionName)
 
       return
     }
@@ -72,13 +71,6 @@ implements DomainEventHandlerInterface
       timestamp,
       timestamp,
     )
-  }
-
-  private async removeOfflineUserRole(
-    email: string,
-    subscriptionName: SubscriptionName
-  ): Promise<void> {
-    await this.roleService.removeOfflineUserRole(email, subscriptionName)
   }
 
   private async updateOfflineSubscriptionEndsAt(

--- a/src/Domain/Handler/SubscriptionPurchasedEventHandler.spec.ts
+++ b/src/Domain/Handler/SubscriptionPurchasedEventHandler.spec.ts
@@ -59,6 +59,7 @@ describe('SubscriptionPurchasedEventHandler', () => {
     offlineUserSubscription = {} as jest.Mocked<OfflineUserSubscription>
 
     offlineUserSubscriptionRepository = {} as jest.Mocked<OfflineUserSubscriptionRepositoryInterface>
+    offlineUserSubscriptionRepository.findOneBySubscriptionId = jest.fn().mockReturnValue(offlineUserSubscription)
     offlineUserSubscriptionRepository.save = jest.fn().mockReturnValue(offlineUserSubscription)
 
     roleService = {} as jest.Mocked<RoleServiceInterface>
@@ -104,7 +105,7 @@ describe('SubscriptionPurchasedEventHandler', () => {
 
     await createHandler().handle(event)
 
-    expect(roleService.addOfflineUserRole).toHaveBeenCalledWith('test@test.com', SubscriptionName.ProPlan)
+    expect(roleService.addOfflineUserRole).toHaveBeenCalledWith(offlineUserSubscription)
   })
 
   it('should create subscription', async () => {

--- a/src/Domain/Handler/SubscriptionPurchasedEventHandler.spec.ts
+++ b/src/Domain/Handler/SubscriptionPurchasedEventHandler.spec.ts
@@ -64,7 +64,7 @@ describe('SubscriptionPurchasedEventHandler', () => {
 
     roleService = {} as jest.Mocked<RoleServiceInterface>
     roleService.addUserRole = jest.fn()
-    roleService.addOfflineUserRole = jest.fn()
+    roleService.setOfflineUserRole = jest.fn()
 
     subscriptionExpiresAt = timestamp + 365*1000
 
@@ -105,7 +105,7 @@ describe('SubscriptionPurchasedEventHandler', () => {
 
     await createHandler().handle(event)
 
-    expect(roleService.addOfflineUserRole).toHaveBeenCalledWith(offlineUserSubscription)
+    expect(roleService.setOfflineUserRole).toHaveBeenCalledWith(offlineUserSubscription)
   })
 
   it('should create subscription', async () => {

--- a/src/Domain/Handler/SubscriptionPurchasedEventHandler.ts
+++ b/src/Domain/Handler/SubscriptionPurchasedEventHandler.ts
@@ -42,7 +42,7 @@ implements DomainEventHandlerInterface
         event.payload.timestamp,
       )
 
-      await this.roleService.addOfflineUserRole(offlineUserSubscription)
+      await this.roleService.setOfflineUserRole(offlineUserSubscription)
 
       return
     }

--- a/src/Domain/Handler/SubscriptionPurchasedEventHandler.ts
+++ b/src/Domain/Handler/SubscriptionPurchasedEventHandler.ts
@@ -34,8 +34,6 @@ implements DomainEventHandlerInterface
     event: SubscriptionPurchasedEvent
   ): Promise<void> {
     if (event.payload.offline) {
-      this.logger.info('Creating offline user subscription: %O', event.payload)
-
       const offlineUserSubscription = await this.createOfflineSubscription(
         event.payload.subscriptionId,
         event.payload.subscriptionName,
@@ -44,12 +42,7 @@ implements DomainEventHandlerInterface
         event.payload.timestamp,
       )
 
-      this.logger.info('Created offline user subscription: %O', offlineUserSubscription)
-
-      await this.roleService.addOfflineUserRole(
-        event.payload.userEmail,
-        event.payload.subscriptionName
-      )
+      await this.roleService.addOfflineUserRole(offlineUserSubscription)
 
       return
     }

--- a/src/Domain/Handler/SubscriptionRefundedEventHandler.spec.ts
+++ b/src/Domain/Handler/SubscriptionRefundedEventHandler.spec.ts
@@ -52,7 +52,6 @@ describe('SubscriptionRefundedEventHandler', () => {
 
     roleService = {} as jest.Mocked<RoleServiceInterface>
     roleService.removeUserRole = jest.fn()
-    roleService.removeOfflineUserRole = jest.fn()
 
     timestamp = dayjs.utc().valueOf()
 
@@ -76,14 +75,6 @@ describe('SubscriptionRefundedEventHandler', () => {
 
     expect(userRepository.findOneByEmail).toHaveBeenCalledWith('test@test.com')
     expect(roleService.removeUserRole).toHaveBeenCalledWith(user, SubscriptionName.CorePlan)
-  })
-
-  it('should update the offline user role', async () => {
-    event.payload.offline = true
-
-    await createHandler().handle(event)
-
-    expect(roleService.removeOfflineUserRole).toHaveBeenCalledWith('test@test.com', SubscriptionName.CorePlan)
   })
 
   it('should update subscription ends at', async () => {

--- a/src/Domain/Handler/SubscriptionRefundedEventHandler.ts
+++ b/src/Domain/Handler/SubscriptionRefundedEventHandler.ts
@@ -34,7 +34,6 @@ implements DomainEventHandlerInterface
         event.payload.subscriptionId,
         event.payload.timestamp,
       )
-      await this.removeOfflineUserRole(event.payload.userEmail, event.payload.subscriptionName)
 
       return
     }
@@ -73,13 +72,6 @@ implements DomainEventHandlerInterface
       timestamp,
       timestamp,
     )
-  }
-
-  private async removeOfflineUserRole(
-    email: string,
-    subscriptionName: SubscriptionName
-  ): Promise<void> {
-    await this.roleService.removeOfflineUserRole(email, subscriptionName)
   }
 
   private async updateOfflineSubscriptionEndsAt(

--- a/src/Domain/Handler/SubscriptionRenewedEventHandler.spec.ts
+++ b/src/Domain/Handler/SubscriptionRenewedEventHandler.spec.ts
@@ -65,7 +65,7 @@ describe('SubscriptionRenewedEventHandler', () => {
 
     roleService = {} as jest.Mocked<RoleServiceInterface>
     roleService.addUserRole = jest.fn()
-    roleService.addOfflineUserRole = jest.fn()
+    roleService.setOfflineUserRole = jest.fn()
 
     timestamp = dayjs.utc().valueOf()
     subscriptionExpiresAt = dayjs.utc().valueOf() + 365*1000
@@ -128,7 +128,7 @@ describe('SubscriptionRenewedEventHandler', () => {
 
     await createHandler().handle(event)
 
-    expect(roleService.addOfflineUserRole).toHaveBeenCalledWith(offlineUserSubscription)
+    expect(roleService.setOfflineUserRole).toHaveBeenCalledWith(offlineUserSubscription)
   })
 
   it('should not do anything if no user is found for specified email', async () => {

--- a/src/Domain/Handler/SubscriptionRenewedEventHandler.ts
+++ b/src/Domain/Handler/SubscriptionRenewedEventHandler.ts
@@ -44,7 +44,7 @@ implements DomainEventHandlerInterface
 
       await this.updateOfflineSubscriptionEndsAt(offlineUserSubscription, event.payload.timestamp)
 
-      await this.roleService.addOfflineUserRole(offlineUserSubscription)
+      await this.roleService.setOfflineUserRole(offlineUserSubscription)
 
       return
     }

--- a/src/Domain/Handler/SubscriptionRenewedEventHandler.ts
+++ b/src/Domain/Handler/SubscriptionRenewedEventHandler.ts
@@ -13,6 +13,7 @@ import { RoleServiceInterface } from '../Role/RoleServiceInterface'
 import { UserRepositoryInterface } from '../User/UserRepositoryInterface'
 import { Logger } from 'winston'
 import { SettingServiceInterface } from '../Setting/SettingServiceInterface'
+import { OfflineUserSubscription } from '../Subscription/OfflineUserSubscription'
 
 @injectable()
 export class SubscriptionRenewedEventHandler
@@ -32,15 +33,18 @@ implements DomainEventHandlerInterface
     event: SubscriptionRenewedEvent
   ): Promise<void> {
     if (event.payload.offline) {
-      await this.updateOfflineSubscriptionEndsAt(
-        event.payload.subscriptionId,
-        event.payload.timestamp,
-      )
+      const offlineUserSubscription = await this.offlineUserSubscriptionRepository
+        .findOneBySubscriptionId(event.payload.subscriptionId)
 
-      await this.addOfflineUserRole(
-        event.payload.userEmail,
-        event.payload.subscriptionName
-      )
+      if (offlineUserSubscription === undefined) {
+        this.logger.warn(`Could not find offline user subscription with id: ${event.payload.subscriptionId}`)
+
+        return
+      }
+
+      await this.updateOfflineSubscriptionEndsAt(offlineUserSubscription, event.payload.timestamp)
+
+      await this.roleService.addOfflineUserRole(offlineUserSubscription)
 
       return
     }
@@ -71,13 +75,6 @@ implements DomainEventHandlerInterface
     await this.roleService.addUserRole(user, subscriptionName)
   }
 
-  private async addOfflineUserRole(
-    email: string,
-    subscriptionName: SubscriptionName
-  ): Promise<void> {
-    await this.roleService.addOfflineUserRole(email, subscriptionName)
-  }
-
   private async updateSubscriptionEndsAt(
     subscriptionId: number,
     subscriptionExpiresAt: number,
@@ -91,13 +88,12 @@ implements DomainEventHandlerInterface
   }
 
   private async updateOfflineSubscriptionEndsAt(
-    subscriptionId: number,
+    offlineUserSubscription: OfflineUserSubscription,
     timestamp: number,
   ): Promise<void> {
-    await this.offlineUserSubscriptionRepository.updateEndsAt(
-      subscriptionId,
-      timestamp,
-      timestamp,
-    )
+    offlineUserSubscription.endsAt = timestamp
+    offlineUserSubscription.updatedAt = timestamp
+
+    await this.offlineUserSubscriptionRepository.save(offlineUserSubscription)
   }
 }

--- a/src/Domain/Role/RoleService.spec.ts
+++ b/src/Domain/Role/RoleService.spec.ts
@@ -12,7 +12,6 @@ import { RoleService } from './RoleService'
 import { RoleToSubscriptionMapInterface } from './RoleToSubscriptionMapInterface'
 import { OfflineUserSubscriptionRepositoryInterface } from '../Subscription/OfflineUserSubscriptionRepositoryInterface'
 import { OfflineUserSubscription } from '../Subscription/OfflineUserSubscription'
-import { TimerInterface } from '@standardnotes/time'
 import { PermissionName } from '@standardnotes/features'
 import { Permission } from '../Permission/Permission'
 
@@ -27,8 +26,6 @@ describe('RoleService', () => {
   let user: User
   let basicRole: Role
   let proRole: Role
-  let coreRole: Role
-  let timer: TimerInterface
 
   const createService = () => new RoleService(
     userRepository,
@@ -37,7 +34,6 @@ describe('RoleService', () => {
     webSocketsClientService,
     roleToSubscriptionMap,
     logger,
-    timer,
   )
 
   beforeEach(() => {
@@ -59,10 +55,6 @@ describe('RoleService', () => {
       ]),
     } as jest.Mocked<Role>
 
-    coreRole = {
-      name: RoleName.CoreUser,
-    } as jest.Mocked<Role>
-
     userRepository = {} as jest.Mocked<UserRepositoryInterface>
 
     roleRepository = {} as jest.Mocked<RoleRepositoryInterface>
@@ -74,8 +66,8 @@ describe('RoleService', () => {
     offlineUserSubscription = {
       endsAt: 100,
       cancelled: false,
+      planName: SubscriptionName.ProPlan,
     } as jest.Mocked<OfflineUserSubscription>
-    offlineUserSubscription.roles = Promise.resolve([ coreRole ])
 
     offlineUserSubscriptionRepository = {} as jest.Mocked<OfflineUserSubscriptionRepositoryInterface>
     offlineUserSubscriptionRepository.findOneByEmail = jest.fn().mockReturnValue(offlineUserSubscription)
@@ -83,9 +75,6 @@ describe('RoleService', () => {
 
     webSocketsClientService = {} as jest.Mocked<ClientServiceInterface>
     webSocketsClientService.sendUserRolesChangedEvent = jest.fn()
-
-    timer = {} as jest.Mocked<TimerInterface>
-    timer.getTimestampInMicroseconds = jest.fn().mockReturnValue(3)
 
     logger = {} as jest.Mocked<Logger>
     logger.info = jest.fn()
@@ -160,30 +149,21 @@ describe('RoleService', () => {
     })
 
     it('should add offline role to offline subscription', async () => {
-      await createService().addOfflineUserRole('test@test.com', SubscriptionName.ProPlan)
+      await createService().addOfflineUserRole(offlineUserSubscription)
 
       expect(roleRepository.findOneByName).toHaveBeenCalledWith(RoleName.ProUser)
       expect(offlineUserSubscriptionRepository.save).toHaveBeenCalledWith({
         endsAt: 100,
         cancelled: false,
-        roles: Promise.resolve([ coreRole, proRole ]),
+        planName: SubscriptionName.ProPlan,
+        roles: Promise.resolve([ proRole ]),
       })
-    })
-
-    it('should not add duplicate offline role to offline subscription', async () => {
-      roleToSubscriptionMap.getRoleNameForSubscriptionName = jest.fn().mockReturnValue(RoleName.CoreUser)
-      roleRepository.findOneByName = jest.fn().mockReturnValue(coreRole)
-
-      await createService().addOfflineUserRole('test@test.com', SubscriptionName.CorePlan)
-
-      expect(roleRepository.findOneByName).toHaveBeenCalledWith(RoleName.CoreUser)
-      expect(await offlineUserSubscription.roles).toHaveLength(1)
     })
 
     it('should not add offline role if no role name exists for subscription name', async () => {
       roleToSubscriptionMap.getRoleNameForSubscriptionName = jest.fn().mockReturnValue(undefined)
 
-      await createService().addOfflineUserRole('test@test.com', 'test' as SubscriptionName)
+      await createService().addOfflineUserRole(offlineUserSubscription)
 
       expect(offlineUserSubscriptionRepository.save).not.toHaveBeenCalled()
     })
@@ -191,24 +171,7 @@ describe('RoleService', () => {
     it('should not add offline role if no role exists for role name', async () => {
       roleRepository.findOneByName = jest.fn().mockReturnValue(undefined)
 
-      await createService().addOfflineUserRole('test@test.com', SubscriptionName.ProPlan)
-
-      expect(offlineUserSubscriptionRepository.save).not.toHaveBeenCalled()
-    })
-
-    it('should not add offline role if no offline subscription is found', async () => {
-      offlineUserSubscriptionRepository.findOneByEmail = jest.fn().mockReturnValue(undefined)
-
-      await createService().addOfflineUserRole('test@test.com', SubscriptionName.ProPlan)
-
-      expect(offlineUserSubscriptionRepository.save).not.toHaveBeenCalled()
-    })
-
-    it('should not add offline role if offline subscription is expired', async () => {
-      offlineUserSubscription.endsAt = 2
-      offlineUserSubscriptionRepository.findOneByEmail = jest.fn().mockReturnValue(offlineUserSubscription)
-
-      await createService().addOfflineUserRole('test@test.com', SubscriptionName.ProPlan)
+      await createService().addOfflineUserRole(offlineUserSubscription)
 
       expect(offlineUserSubscriptionRepository.save).not.toHaveBeenCalled()
     })
@@ -235,16 +198,6 @@ describe('RoleService', () => {
       expect(userRepository.save).toHaveBeenCalledWith(user)
     })
 
-    it('should remove role from offline subscription', async () => {
-      await createService().removeOfflineUserRole('test@test.com', SubscriptionName.ProPlan)
-
-      expect(offlineUserSubscriptionRepository.save).toHaveBeenCalledWith({
-        endsAt: 100,
-        cancelled: false,
-        roles: Promise.resolve([]),
-      })
-    })
-
     it('should send websockets event', async () => {
       await createService().removeUserRole(user, SubscriptionName.ProPlan)
 
@@ -259,22 +212,6 @@ describe('RoleService', () => {
       await createService().removeUserRole(user, 'test' as SubscriptionName)
 
       expect(userRepository.save).not.toHaveBeenCalled()
-    })
-
-    it('should not remove offline role if role name does not exist for subscription name', async () => {
-      roleToSubscriptionMap.getRoleNameForSubscriptionName = jest.fn().mockReturnValue(undefined)
-
-      await createService().removeOfflineUserRole('test@test.com', 'test' as SubscriptionName)
-
-      expect(offlineUserSubscriptionRepository.save).not.toHaveBeenCalled()
-    })
-
-    it('should not remove offline role if no subscription exists for user email', async () => {
-      offlineUserSubscriptionRepository.findOneByEmail = jest.fn().mockReturnValue(undefined)
-
-      await createService().removeOfflineUserRole('test@test.com', SubscriptionName.ProPlan)
-
-      expect(offlineUserSubscriptionRepository.save).not.toHaveBeenCalled()
     })
   })
 

--- a/src/Domain/Role/RoleService.spec.ts
+++ b/src/Domain/Role/RoleService.spec.ts
@@ -148,8 +148,8 @@ describe('RoleService', () => {
       expect(userRepository.save).not.toHaveBeenCalled()
     })
 
-    it('should add offline role to offline subscription', async () => {
-      await createService().addOfflineUserRole(offlineUserSubscription)
+    it('should set offline role to offline subscription', async () => {
+      await createService().setOfflineUserRole(offlineUserSubscription)
 
       expect(roleRepository.findOneByName).toHaveBeenCalledWith(RoleName.ProUser)
       expect(offlineUserSubscriptionRepository.save).toHaveBeenCalledWith({
@@ -160,18 +160,18 @@ describe('RoleService', () => {
       })
     })
 
-    it('should not add offline role if no role name exists for subscription name', async () => {
+    it('should not set offline role if no role name exists for subscription name', async () => {
       roleToSubscriptionMap.getRoleNameForSubscriptionName = jest.fn().mockReturnValue(undefined)
 
-      await createService().addOfflineUserRole(offlineUserSubscription)
+      await createService().setOfflineUserRole(offlineUserSubscription)
 
       expect(offlineUserSubscriptionRepository.save).not.toHaveBeenCalled()
     })
 
-    it('should not add offline role if no role exists for role name', async () => {
+    it('should not set offline role if no role exists for role name', async () => {
       roleRepository.findOneByName = jest.fn().mockReturnValue(undefined)
 
-      await createService().addOfflineUserRole(offlineUserSubscription)
+      await createService().setOfflineUserRole(offlineUserSubscription)
 
       expect(offlineUserSubscriptionRepository.save).not.toHaveBeenCalled()
     })

--- a/src/Domain/Role/RoleService.ts
+++ b/src/Domain/Role/RoleService.ts
@@ -83,7 +83,7 @@ export class RoleService implements RoleServiceInterface {
     )
   }
 
-  async addOfflineUserRole(offlineUserSubscription: OfflineUserSubscription): Promise<void> {
+  async setOfflineUserRole(offlineUserSubscription: OfflineUserSubscription): Promise<void> {
     const roleName = this.roleToSubscriptionMap
       .getRoleNameForSubscriptionName(offlineUserSubscription.planName as SubscriptionName)
 

--- a/src/Domain/Role/RoleService.ts
+++ b/src/Domain/Role/RoleService.ts
@@ -11,8 +11,8 @@ import { RoleRepositoryInterface } from './RoleRepositoryInterface'
 import { RoleServiceInterface } from './RoleServiceInterface'
 import { RoleToSubscriptionMapInterface } from './RoleToSubscriptionMapInterface'
 import { OfflineUserSubscriptionRepositoryInterface } from '../Subscription/OfflineUserSubscriptionRepositoryInterface'
-import { TimerInterface } from '@standardnotes/time'
 import { Role } from './Role'
+import { OfflineUserSubscription } from '../Subscription/OfflineUserSubscription'
 
 @injectable()
 export class RoleService implements RoleServiceInterface {
@@ -23,7 +23,6 @@ export class RoleService implements RoleServiceInterface {
     @inject(TYPES.WebSocketsClientService) private webSocketsClientService: ClientServiceInterface,
     @inject(TYPES.RoleToSubscriptionMap) private roleToSubscriptionMap: RoleToSubscriptionMapInterface,
     @inject(TYPES.Logger) private logger: Logger,
-    @inject(TYPES.Timer) private timer: TimerInterface,
   ) {
   }
 
@@ -84,18 +83,12 @@ export class RoleService implements RoleServiceInterface {
     )
   }
 
-  async addOfflineUserRole(
-    email: string,
-    subscriptionName: SubscriptionName,
-  ): Promise<void> {
-    this.logger.info(`Adding offline user ${email} a role for subscription ${subscriptionName}`)
-
-    const roleName = this.roleToSubscriptionMap.getRoleNameForSubscriptionName(subscriptionName)
-
-    this.logger.info(`Found role ${roleName} for subscription name ${subscriptionName}`)
+  async addOfflineUserRole(offlineUserSubscription: OfflineUserSubscription): Promise<void> {
+    const roleName = this.roleToSubscriptionMap
+      .getRoleNameForSubscriptionName(offlineUserSubscription.planName as SubscriptionName)
 
     if (roleName === undefined) {
-      this.logger.warn(`Could not find role name for subscription name: ${subscriptionName}`)
+      this.logger.warn(`Could not find role name for subscription name: ${offlineUserSubscription.planName}`)
 
       return
     }
@@ -108,36 +101,9 @@ export class RoleService implements RoleServiceInterface {
       return
     }
 
-    const currentSubscription = await this.offlineUserSubscriptionRepository.findOneByEmail(email)
-    if (currentSubscription === undefined) {
-      this.logger.warn(`Unable to add offline roles due to no offline subscription for email: ${email}`)
+    offlineUserSubscription.roles = Promise.resolve([role])
 
-      return
-    }
-
-    const now = this.timer.getTimestampInMicroseconds()
-
-    if (currentSubscription.endsAt < now) {
-      this.logger.warn(
-        `Unable to add offline roles due to expired subscription for email ${email}.
-        The subscription endsAt ${currentSubscription.endsAt} compared to
-        the current timestamp of ${now}`
-      )
-
-      return
-    }
-
-    const rolesMap = new Map<string, Role>()
-    const currentRoles = await currentSubscription.roles
-    for (const currentRole of currentRoles) {
-      rolesMap.set(currentRole.name, currentRole)
-    }
-    if (!rolesMap.has(role.name)) {
-      rolesMap.set(role.name, role)
-    }
-    currentSubscription.roles = Promise.resolve([...rolesMap.values()])
-
-    await this.offlineUserSubscriptionRepository.save(currentSubscription)
+    await this.offlineUserSubscriptionRepository.save(offlineUserSubscription)
   }
 
   async removeUserRole(
@@ -161,32 +127,5 @@ export class RoleService implements RoleServiceInterface {
     await this.webSocketsClientService.sendUserRolesChangedEvent(
       user,
     )
-  }
-
-  async removeOfflineUserRole(
-    email: string,
-    subscriptionName: SubscriptionName,
-  ): Promise<void> {
-    const roleName = this.roleToSubscriptionMap.getRoleNameForSubscriptionName(subscriptionName)
-
-    if (roleName === undefined) {
-      this.logger.warn(
-        `Could not find role name for subscription name: ${subscriptionName}`
-      )
-      return
-    }
-
-    const currentSubscription = await this.offlineUserSubscriptionRepository.findOneByEmail(email)
-    if (currentSubscription === undefined) {
-      this.logger.warn(`Could not find current subscription for email: ${email}`)
-
-      return
-    }
-
-    const currentRoles = await currentSubscription.roles
-    currentSubscription.roles = Promise.resolve(
-      currentRoles.filter(role => role.name !== roleName)
-    )
-    await this.offlineUserSubscriptionRepository.save(currentSubscription)
   }
 }

--- a/src/Domain/Role/RoleServiceInterface.ts
+++ b/src/Domain/Role/RoleServiceInterface.ts
@@ -5,7 +5,7 @@ import { User } from '../User/User'
 
 export interface RoleServiceInterface {
   addUserRole(user: User, subscriptionName: SubscriptionName): Promise<void>
-  addOfflineUserRole(offlineUserSubscription: OfflineUserSubscription): Promise<void>
+  setOfflineUserRole(offlineUserSubscription: OfflineUserSubscription): Promise<void>
   removeUserRole(user: User, subscriptionName: SubscriptionName): Promise<void>
   userHasPermission(userUuid: string, permissionName: PermissionName): Promise<boolean>
 }

--- a/src/Domain/Role/RoleServiceInterface.ts
+++ b/src/Domain/Role/RoleServiceInterface.ts
@@ -1,11 +1,11 @@
 import { SubscriptionName } from '@standardnotes/auth'
 import { PermissionName } from '@standardnotes/features'
+import { OfflineUserSubscription } from '../Subscription/OfflineUserSubscription'
 import { User } from '../User/User'
 
 export interface RoleServiceInterface {
   addUserRole(user: User, subscriptionName: SubscriptionName): Promise<void>
-  addOfflineUserRole(email: string, subscriptionName: SubscriptionName): Promise<void>
+  addOfflineUserRole(offlineUserSubscription: OfflineUserSubscription): Promise<void>
   removeUserRole(user: User, subscriptionName: SubscriptionName): Promise<void>
-  removeOfflineUserRole(email: string, subscriptionName: SubscriptionName): Promise<void>
   userHasPermission(userUuid: string, permissionName: PermissionName): Promise<boolean>
 }

--- a/src/Domain/Subscription/OfflineUserSubscriptionRepositoryInterface.ts
+++ b/src/Domain/Subscription/OfflineUserSubscriptionRepositoryInterface.ts
@@ -2,6 +2,7 @@ import { OfflineUserSubscription } from './OfflineUserSubscription'
 
 export interface OfflineUserSubscriptionRepositoryInterface {
   findOneByEmail(email: string): Promise<OfflineUserSubscription | undefined>
+  findOneBySubscriptionId(subscriptionId: number): Promise<OfflineUserSubscription | undefined>
   findByEmail(email: string, activeAfter: number): Promise<OfflineUserSubscription[]>
   updateEndsAt(subscriptionId: number, endsAt: number, updatedAt: number): Promise<void>
   updateCancelled(subscriptionId: number, cancelled: boolean, updatedAt: number): Promise<void>

--- a/src/Infra/MySQL/MySQLOfflineUserSubscriptionRepository.spec.ts
+++ b/src/Infra/MySQL/MySQLOfflineUserSubscriptionRepository.spec.ts
@@ -173,4 +173,22 @@ describe('MySQLOfflineUserSubscriptionRepository', () => {
     )
     expect(updateQueryBuilder.execute).toHaveBeenCalled()
   })
+
+  it('should find one offline user subscription by user subscription id', async () => {
+    repository.createQueryBuilder = jest.fn().mockImplementation(() => selectQueryBuilder)
+
+    selectQueryBuilder.where = jest.fn().mockReturnThis()
+    selectQueryBuilder.getOne = jest.fn().mockReturnValue(offlineSubscription)
+
+    const result = await repository.findOneBySubscriptionId(123)
+
+    expect(selectQueryBuilder.where).toHaveBeenCalledWith(
+      'offline_user_subscription.subscription_id = :subscriptionId',
+      {
+        subscriptionId: 123,
+      },
+    )
+    expect(selectQueryBuilder.getOne).toHaveBeenCalled()
+    expect(result).toEqual(offlineSubscription)
+  })
 })

--- a/src/Infra/MySQL/MySQLOfflineUserSubscriptionRepository.ts
+++ b/src/Infra/MySQL/MySQLOfflineUserSubscriptionRepository.ts
@@ -6,6 +6,17 @@ import { OfflineUserSubscriptionRepositoryInterface } from '../../Domain/Subscri
 @injectable()
 @EntityRepository(OfflineUserSubscription)
 export class MySQLOfflineUserSubscriptionRepository extends Repository<OfflineUserSubscription> implements OfflineUserSubscriptionRepositoryInterface {
+  async findOneBySubscriptionId(subscriptionId: number): Promise<OfflineUserSubscription | undefined> {
+    return await this.createQueryBuilder('offline_user_subscription')
+      .where(
+        'offline_user_subscription.subscription_id = :subscriptionId',
+        {
+          subscriptionId,
+        }
+      )
+      .getOne()
+  }
+
   async findByEmail(email: string, activeAfter: number): Promise<OfflineUserSubscription[]> {
     return await this.createQueryBuilder('offline_user_subscription')
       .where(
@@ -30,13 +41,7 @@ export class MySQLOfflineUserSubscriptionRepository extends Repository<OfflineUs
       .orderBy('offline_user_subscription.ends_at', 'DESC')
       .getMany()
 
-    /* istanbul ignore next */
-    console.log(`Found ${subscriptions.length} offline user subscriptions`)
-
     const uncanceled = subscriptions.find((subscription) => !subscription.cancelled)
-
-    /* istanbul ignore next */
-    console.log(`Uncanceled subscription: ${uncanceled}`)
 
     return uncanceled || subscriptions[0]
   }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Description

There was a bug that often occurred for handling events related to offline subscriptions. The issue was a read-after-write hazard.

The main misconception was that we were **adding** offline user roles, just like in the case of an online user (one-to-many). Whereas what we should be doing is **setting** an offline role to the offline subscription (one-to-one). Same goes for removing - not needed in the case of offline subscriptions because of an offline subscription having only one role. 

## Related Issue(s)

Internal link: https://app.asana.com/0/1200980603427038/1201520197064595/f

## Production Ready?

- [x] This is ready to go out to production ASAP
