### PR TITLE
fix: add setting name validation

### DIFF
--- a/src/Domain/UseCase/UpdateSetting/UpdateSetting.spec.ts
+++ b/src/Domain/UseCase/UpdateSetting/UpdateSetting.spec.ts
@@ -13,6 +13,7 @@ import { SimpleSetting } from '../../Setting/SimpleSetting'
 import { User } from '../../User/User'
 import { UserRepositoryInterface } from '../../User/UserRepositoryInterface'
 import { UpdateSetting } from './UpdateSetting'
+import { SettingName } from '@standardnotes/settings'
 
 describe('UpdateSetting', () => {
   let settingService: SettingServiceInterface
@@ -62,7 +63,7 @@ describe('UpdateSetting', () => {
 
   it('should create a setting', async () => {
     const props = {
-      name: 'test-setting-name',
+      name: SettingName.ExtensionKey,
       value: 'test-setting-value',
       serverEncryptionVersion: EncryptionVersion.Default,
       sensitive: false,
@@ -72,7 +73,7 @@ describe('UpdateSetting', () => {
 
     expect(settingService.createOrReplace).toHaveBeenCalledWith({
       props: {
-        name: 'test-setting-name',
+        name: 'EXTENSION_KEY',
         value: 'test-setting-value',
         serverEncryptionVersion: 1,
         sensitive: false,
@@ -91,7 +92,7 @@ describe('UpdateSetting', () => {
     userRepository.findOneByUuid = jest.fn().mockReturnValue(undefined)
 
     const props = {
-      name: 'test-setting-name',
+      name: SettingName.ExtensionKey,
       value: 'test-setting-value',
       serverEncryptionVersion: EncryptionVersion.Unencrypted,
       sensitive: false,
@@ -110,13 +111,34 @@ describe('UpdateSetting', () => {
     })
   })
 
+  it('should not create a setting if the setting name is invalid', async () => {
+    const props = {
+      name: 'random-setting',
+      value: 'test-setting-value',
+      serverEncryptionVersion: EncryptionVersion.Unencrypted,
+      sensitive: false,
+    }
+
+    const response = await createUseCase().execute({ props, userUuid: '1-2-3' })
+
+    expect(settingService.createOrReplace).not.toHaveBeenCalled()
+
+    expect(response).toEqual({
+      success: false,
+      error: {
+        message: 'Setting name random-setting is invalid.',
+      },
+      statusCode: 400,
+    })
+  })
+
   it('should not create a setting if user is not permitted to', async () => {
     settingToSubscriptionMap.getPermissionAssociatedWithSetting = jest.fn().mockReturnValue(PermissionName.DailyEmailBackup)
 
     roleService.userHasPermission = jest.fn().mockReturnValue(false)
 
     const props = {
-      name: 'test-setting-name',
+      name: SettingName.ExtensionKey,
       value: 'test-setting-value',
       serverEncryptionVersion: EncryptionVersion.Unencrypted,
       sensitive: false,

--- a/src/Domain/UseCase/UpdateSetting/UpdateSetting.ts
+++ b/src/Domain/UseCase/UpdateSetting/UpdateSetting.ts
@@ -26,6 +26,16 @@ export class UpdateSetting implements UseCaseInterface {
   }
 
   async execute(dto: UpdateSettingDto): Promise<UpdateSettingResponse> {
+    if (!Object.values(SettingName).includes(dto.props.name as SettingName)) {
+      return {
+        success: false,
+        error: {
+          message: `Setting name ${dto.props.name} is invalid.`,
+        },
+        statusCode: 400,
+      }
+    }
+
     this.logger.debug('[%s] Updating setting: %O', dto.userUuid, dto)
 
     const { userUuid, props } = dto


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Description

Add validation of setting name to not allow any name to be passed down

## Related Issue(s)

https://app.asana.com/0/0/1201566773573828/f

## Production Ready?

- [x] This is ready to go out to production ASAP
