### PR TITLE
fix: passing unencrypted value of a setting to cloud backup event

### DIFF
--- a/src/Controller/SettingsController.spec.ts
+++ b/src/Controller/SettingsController.spec.ts
@@ -161,7 +161,7 @@ describe('SettingsController', () => {
         name: 'foo',
         sensitive: false,
         serverEncryptionVersion: 1,
-        value: 'bar',
+        unencryptedValue: 'bar',
       },
       userUuid: '1-2-3',
     })
@@ -191,7 +191,7 @@ describe('SettingsController', () => {
         name: 'foo',
         sensitive: false,
         serverEncryptionVersion: 0,
-        value: 'bar',
+        unencryptedValue: 'bar',
       },
       userUuid: '1-2-3',
     })
@@ -243,7 +243,7 @@ describe('SettingsController', () => {
         name: 'foo',
         serverEncryptionVersion: 1,
         sensitive: false,
-        value: 'bar',
+        unencryptedValue: 'bar',
       },
       userUuid: '1-2-3',
     })

--- a/src/Controller/SettingsController.ts
+++ b/src/Controller/SettingsController.ts
@@ -84,7 +84,7 @@ export class SettingsController extends BaseHttpController {
 
     const props = {
       name,
-      value,
+      unencryptedValue: value,
       serverEncryptionVersion,
       sensitive,
     }

--- a/src/Domain/Handler/ExtensionKeyGrantedEventHandler.spec.ts
+++ b/src/Domain/Handler/ExtensionKeyGrantedEventHandler.spec.ts
@@ -104,7 +104,7 @@ describe('ExtensionKeyGrantedEventHandler', () => {
       props: {
         name: 'EXTENSION_KEY',
         serverEncryptionVersion: 1,
-        value: 'abc123',
+        unencryptedValue: 'abc123',
         sensitive: true,
       },
       user: {

--- a/src/Domain/Handler/ExtensionKeyGrantedEventHandler.ts
+++ b/src/Domain/Handler/ExtensionKeyGrantedEventHandler.ts
@@ -61,7 +61,7 @@ export class ExtensionKeyGrantedEventHandler implements DomainEventHandlerInterf
       user,
       props: {
         name: SettingName.ExtensionKey,
-        value: event.payload.extensionKey,
+        unencryptedValue: event.payload.extensionKey,
         serverEncryptionVersion: EncryptionVersion.Default,
         sensitive: true,
       },

--- a/src/Domain/Handler/SubscriptionReassignedEventHandler.spec.ts
+++ b/src/Domain/Handler/SubscriptionReassignedEventHandler.spec.ts
@@ -116,7 +116,7 @@ describe('SubscriptionReassignedEventHandler', () => {
       props: {
         name: 'EXTENSION_KEY',
         serverEncryptionVersion: 1,
-        value: 'abc123',
+        unencryptedValue: 'abc123',
         sensitive: true,
       },
       user: {

--- a/src/Domain/Handler/SubscriptionReassignedEventHandler.ts
+++ b/src/Domain/Handler/SubscriptionReassignedEventHandler.ts
@@ -56,7 +56,7 @@ implements DomainEventHandlerInterface
       user,
       props: {
         name: SettingName.ExtensionKey,
-        value: event.payload.extensionKey,
+        unencryptedValue: event.payload.extensionKey,
         serverEncryptionVersion: EncryptionVersion.Default,
         sensitive: true,
       },

--- a/src/Domain/Handler/SubscriptionSyncRequestedEventHandler.spec.ts
+++ b/src/Domain/Handler/SubscriptionSyncRequestedEventHandler.spec.ts
@@ -123,7 +123,7 @@ describe('SubscriptionSyncRequestedEventHandler', () => {
       props: {
         name: 'EXTENSION_KEY',
         serverEncryptionVersion: 1,
-        value: 'abc123',
+        unencryptedValue: 'abc123',
         sensitive: true,
       },
       user: {

--- a/src/Domain/Handler/SubscriptionSyncRequestedEventHandler.ts
+++ b/src/Domain/Handler/SubscriptionSyncRequestedEventHandler.ts
@@ -98,7 +98,7 @@ implements DomainEventHandlerInterface
       user,
       props: {
         name: SettingName.ExtensionKey,
-        value: event.payload.extensionKey,
+        unencryptedValue: event.payload.extensionKey,
         serverEncryptionVersion: EncryptionVersion.Default,
         sensitive: true,
       },

--- a/src/Domain/Setting/SettingFactory.spec.ts
+++ b/src/Domain/Setting/SettingFactory.spec.ts
@@ -1,5 +1,6 @@
-import { TimerInterface } from '@standardnotes/time'
 import 'reflect-metadata'
+
+import { TimerInterface } from '@standardnotes/time'
 import { CrypterInterface } from '../Encryption/CrypterInterface'
 import { EncryptionVersion } from '../Encryption/EncryptionVersion'
 import { User } from '../User/User'
@@ -27,7 +28,7 @@ describe('SettingFactory', () => {
   it('should create a Setting', async () => {
     const props: SettingProps = {
       name: 'name',
-      value: 'value',
+      unencryptedValue: 'value',
       serverEncryptionVersion: EncryptionVersion.Unencrypted,
       sensitive: false,
     }
@@ -51,7 +52,7 @@ describe('SettingFactory', () => {
 
     const props: SettingProps = {
       name: 'name',
-      value: 'value2',
+      unencryptedValue: 'value2',
       serverEncryptionVersion: EncryptionVersion.Unencrypted,
       sensitive: true,
     }
@@ -74,7 +75,7 @@ describe('SettingFactory', () => {
     const value = 'value'
     const props: SettingProps = {
       name: 'name',
-      value,
+      unencryptedValue: value,
       sensitive: false,
     }
 
@@ -97,7 +98,7 @@ describe('SettingFactory', () => {
     const value = 'value'
     const props: SettingProps = {
       name: 'name',
-      value,
+      unencryptedValue: value,
       serverEncryptionVersion: 99999999999,
       sensitive: false,
     }

--- a/src/Domain/Setting/SettingFactory.ts
+++ b/src/Domain/Setting/SettingFactory.ts
@@ -23,7 +23,7 @@ export class SettingFactory {
 
     const {
       name,
-      value,
+      unencryptedValue,
       serverEncryptionVersion = EncryptionVersion.Default,
       sensitive,
     } = props
@@ -33,7 +33,7 @@ export class SettingFactory {
       user: (async () => user)(),
       name,
       value: await this.createValue({
-        value,
+        unencryptedValue,
         serverEncryptionVersion,
         user,
       }),
@@ -58,19 +58,19 @@ export class SettingFactory {
   }
 
   async createValue({
-    value,
+    unencryptedValue,
     serverEncryptionVersion,
     user,
   }: {
-    value: string | null,
+    unencryptedValue: string | null,
     serverEncryptionVersion: number,
     user: User
   }): Promise<string | null> {
     switch(serverEncryptionVersion) {
     case EncryptionVersion.Unencrypted:
-      return value
+      return unencryptedValue
     case EncryptionVersion.Default:
-      return this.crypter.encryptForUser(value as string, user)
+      return this.crypter.encryptForUser(unencryptedValue as string, user)
     default:
       throw Error(`Unrecognized encryption version: ${serverEncryptionVersion}!`)
     }

--- a/src/Domain/Setting/SettingProps.ts
+++ b/src/Domain/Setting/SettingProps.ts
@@ -5,10 +5,12 @@ export type SettingProps = Omit<Setting,
   'user' |
   'createdAt' |
   'updatedAt' |
-  'serverEncryptionVersion'
+  'serverEncryptionVersion' |
+  'value'
 > & {
   uuid?: string,
   createdAt?: number,
   updatedAt?: number,
+  unencryptedValue: string | null,
   serverEncryptionVersion?: number
 }

--- a/src/Domain/Setting/SettingService.spec.ts
+++ b/src/Domain/Setting/SettingService.spec.ts
@@ -103,7 +103,7 @@ describe('SettingService', () => {
       user,
       props: {
         name: 'name',
-        value: 'value',
+        unencryptedValue: 'value',
         serverEncryptionVersion: 1,
         sensitive: false,
       },
@@ -123,7 +123,7 @@ describe('SettingService', () => {
       user,
       props: {
         name: SettingName.EmailBackupFrequency,
-        value: 'value',
+        unencryptedValue: 'value',
         serverEncryptionVersion: 1,
         sensitive: false,
       },
@@ -150,7 +150,7 @@ describe('SettingService', () => {
       user,
       props: {
         name: SettingName.EmailBackupFrequency,
-        value: 'value',
+        unencryptedValue: 'value',
         serverEncryptionVersion: 1,
         sensitive: false,
       },
@@ -173,7 +173,7 @@ describe('SettingService', () => {
       user,
       props: {
         name: SettingName.DropboxBackupToken,
-        value: 'test-token',
+        unencryptedValue: 'test-token',
         serverEncryptionVersion: 1,
         sensitive: true,
       },
@@ -206,7 +206,7 @@ describe('SettingService', () => {
       user,
       props: {
         name: SettingName.DropboxBackupToken,
-        value: 'test-token',
+        unencryptedValue: 'test-token',
         serverEncryptionVersion: 1,
         sensitive: true,
       },
@@ -235,7 +235,7 @@ describe('SettingService', () => {
       user,
       props: {
         name: SettingName.GoogleDriveBackupToken,
-        value: 'test-token',
+        unencryptedValue: 'test-token',
         serverEncryptionVersion: 1,
         sensitive: true,
       },
@@ -264,7 +264,7 @@ describe('SettingService', () => {
       user,
       props: {
         name: SettingName.OneDriveBackupToken,
-        value: 'test-token',
+        unencryptedValue: 'test-token',
         serverEncryptionVersion: 1,
         sensitive: true,
       },
@@ -307,7 +307,7 @@ describe('SettingService', () => {
       user,
       props: {
         name: SettingName.OneDriveBackupFrequency,
-        value: 'daily',
+        unencryptedValue: 'daily',
         serverEncryptionVersion: 0,
         sensitive: false,
       },
@@ -345,7 +345,7 @@ describe('SettingService', () => {
       user,
       props: {
         name: SettingName.OneDriveBackupFrequency,
-        value: 'daily',
+        unencryptedValue: 'daily',
         serverEncryptionVersion: 0,
         sensitive: false,
       },
@@ -365,7 +365,7 @@ describe('SettingService', () => {
       props: {
         uuid: '1-2-3',
         name: 'name',
-        value: 'value',
+        unencryptedValue: 'value',
         serverEncryptionVersion: 1,
         sensitive: false,
       },
@@ -381,7 +381,7 @@ describe('SettingService', () => {
       user: user,
       props: {
         ...setting,
-        value: 'value',
+        unencryptedValue: 'value',
         serverEncryptionVersion: 1,
       },
     })
@@ -397,7 +397,7 @@ describe('SettingService', () => {
       props: {
         ...setting,
         uuid: '1-2-3',
-        value: 'value',
+        unencryptedValue: 'value',
         serverEncryptionVersion: 1,
       },
     })

--- a/src/Domain/UseCase/UpdateSetting/UpdateSetting.spec.ts
+++ b/src/Domain/UseCase/UpdateSetting/UpdateSetting.spec.ts
@@ -65,7 +65,7 @@ describe('UpdateSetting', () => {
   it('should create a setting', async () => {
     const props = {
       name: SettingName.ExtensionKey,
-      value: 'test-setting-value',
+      unencryptedValue: 'test-setting-value',
       serverEncryptionVersion: EncryptionVersion.Default,
       sensitive: false,
     }
@@ -75,7 +75,7 @@ describe('UpdateSetting', () => {
     expect(settingService.createOrReplace).toHaveBeenCalledWith({
       props: {
         name: 'EXTENSION_KEY',
-        value: 'test-setting-value',
+        unencryptedValue: 'test-setting-value',
         serverEncryptionVersion: 1,
         sensitive: false,
       },
@@ -94,7 +94,7 @@ describe('UpdateSetting', () => {
 
     const props = {
       name: SettingName.ExtensionKey,
-      value: 'test-setting-value',
+      unencryptedValue: 'test-setting-value',
       serverEncryptionVersion: EncryptionVersion.Unencrypted,
       sensitive: false,
     }
@@ -115,7 +115,7 @@ describe('UpdateSetting', () => {
   it('should not create a setting if the setting name is invalid', async () => {
     const props = {
       name: 'random-setting',
-      value: 'test-setting-value',
+      unencryptedValue: 'test-setting-value',
       serverEncryptionVersion: EncryptionVersion.Unencrypted,
       sensitive: false,
     }
@@ -140,7 +140,7 @@ describe('UpdateSetting', () => {
 
     const props = {
       name: SettingName.ExtensionKey,
-      value: 'test-setting-value',
+      unencryptedValue: 'test-setting-value',
       serverEncryptionVersion: EncryptionVersion.Unencrypted,
       sensitive: false,
     }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## Description

In some scenarios an encrypted backup token value was passed to the cloud backup event. This fixes the problem.

## Related Issue(s)

https://app.asana.com/0/1201610838193044/1201547828356716/f

## Production Ready?

- [ ] This is ready to go out to production ASAP
