### PR TITLE
feat: add validation active subscription upon valet token creation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,23 +1,10 @@
-## PR Type
-What kind of change does this PR introduce?
-
-- [ ] Bugfix
-- [ ] Feature
-- [ ] Code style update (formatting, local variables)
-- [ ] Refactoring (no functional changes, no api changes)
-- [ ] Build related changes
-- [ ] CI related changes
-- [ ] Documentation content changes
-- [ ] Tests
-- [ ] Other
-
 ## Description
 
-<!--- describe what's new here -->
+
 
 ## Related Issue(s)
 
-Internal link: <!--- place task link here -->
+Internal link
 
 ## Production Ready?
 

--- a/src/Domain/UseCase/CreateValetToken/CreateValetToken.spec.ts
+++ b/src/Domain/UseCase/CreateValetToken/CreateValetToken.spec.ts
@@ -3,15 +3,22 @@ import 'reflect-metadata'
 import { TokenEncoderInterface, ValetTokenData } from '@standardnotes/auth'
 import { CreateValetToken } from './CreateValetToken'
 import { SettingServiceInterface } from '../../Setting/SettingServiceInterface'
+import { UserSubscriptionRepositoryInterface } from '../../Subscription/UserSubscriptionRepositoryInterface'
+import { TimerInterface } from '@standardnotes/time'
+import { UserSubscription } from '../../Subscription/UserSubscription'
 
 describe('CreateValetToken', () => {
   let tokenEncoder: TokenEncoderInterface<ValetTokenData>
   let settingService: SettingServiceInterface
+  let userSubscriptionRepository: UserSubscriptionRepositoryInterface
+  let timer: TimerInterface
   const valetTokenTTL = 123
 
   const createUseCase = () => new CreateValetToken(
     tokenEncoder,
     settingService,
+    userSubscriptionRepository,
+    timer,
     valetTokenTTL
   )
 
@@ -23,6 +30,12 @@ describe('CreateValetToken', () => {
     settingService.findSetting = jest.fn().mockReturnValue({
       value: '123',
     })
+
+    userSubscriptionRepository = {} as jest.Mocked<UserSubscriptionRepositoryInterface>
+    userSubscriptionRepository.findOneByUserUuid = jest.fn().mockReturnValue({ endsAt: 123 } as jest.Mocked<UserSubscription>)
+
+    timer = {} as jest.Mocked<TimerInterface>
+    timer.getTimestampInMicroseconds = jest.fn().mockReturnValue(100)
   })
 
   it('should create a read valet token', async () => {
@@ -35,6 +48,36 @@ describe('CreateValetToken', () => {
     expect(response).toEqual({
       success: true,
       valetToken: 'foobar',
+    })
+  })
+
+  it('should not create a valet token if a user has no subscription', async () => {
+    userSubscriptionRepository.findOneByUserUuid = jest.fn().mockReturnValue(undefined)
+
+    const response = await createUseCase().execute({
+      operation: 'read',
+      userUuid: '1-2-3',
+      resources: ['1-2-3/2-3-4'],
+    })
+
+    expect(response).toEqual({
+      success: false,
+      reason: 'no-subscription',
+    })
+  })
+
+  it('should not create a valet token if a user has an expired subscription', async () => {
+    timer.getTimestampInMicroseconds = jest.fn().mockReturnValue(150)
+
+    const response = await createUseCase().execute({
+      operation: 'read',
+      userUuid: '1-2-3',
+      resources: ['1-2-3/2-3-4'],
+    })
+
+    expect(response).toEqual({
+      success: false,
+      reason: 'expired-subscription',
     })
   })
 

--- a/src/Domain/UseCase/CreateValetToken/CreateValetTokenResponse.ts
+++ b/src/Domain/UseCase/CreateValetToken/CreateValetTokenResponse.ts
@@ -1,5 +1,6 @@
 export type CreateValetTokenResponse = {
   success: false,
+  reason: 'no-subscription' | 'expired-subscription'
 } | {
   success: true,
   valetToken: string,


### PR DESCRIPTION
## Description

Disallow creating valet tokens if use does not have an active subscription

## Related Issue(s)

[Internal link](https://app.asana.com/0/1199942776723820/1201682849820401/f)

## Production Ready?

- [x] This is ready to go out to production ASAP
